### PR TITLE
Added Execution Policy bypass to prevent artifact install failure on Client version of Windows.

### DIFF
--- a/Artifacts/windows-7zip/Artifactfile.json
+++ b/Artifacts/windows-7zip/Artifactfile.json
@@ -9,7 +9,7 @@
   "iconUri": "https://cdn.rawgit.com/ferventcoder/chocolatey-packages/02c21bebe5abb495a56747cbb9b4b5415c933fc0/icons/7zip.svg",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "powershell.exe -File startChocolatey.ps1 -PackageList 7zip.install"
+    "commandToExecute": "powershell.exe -executionpolicy bypass -File startChocolatey.ps1 -PackageList 7zip.install"
 
   }
 }

--- a/Artifacts/windows-chocolatey/Artifactfile.json
+++ b/Artifacts/windows-chocolatey/Artifactfile.json
@@ -16,6 +16,6 @@
     }
   },
   "runCommand": {
-      "commandToExecute": "[concat('powershell.exe -File startChocolatey.ps1', ' -packageList ', parameters('packages'))]"
+      "commandToExecute": "[concat('powershell.exe -executionpolicy bypass -File startChocolatey.ps1', ' -packageList ', parameters('packages'))]"
   }
 }

--- a/Artifacts/windows-dotnet45/Artifactfile.json
+++ b/Artifacts/windows-dotnet45/Artifactfile.json
@@ -9,7 +9,7 @@
   "iconUri": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/Artifacts/windows-dotnet45/dotnet.png",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "powershell.exe -File startChocolatey.ps1 -PackageList dotnet45"
+    "commandToExecute": "powershell.exe -executionpolicy bypass -File startChocolatey.ps1 -PackageList dotnet45"
 
   }
 }

--- a/Artifacts/windows-fiddler/Artifactfile.json
+++ b/Artifacts/windows-fiddler/Artifactfile.json
@@ -9,7 +9,7 @@
   "iconUri": "https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/e4a49519947c3cff55c17a0b08266c56b0613e64/icons/fiddler.svg",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "powershell.exe -File startChocolatey.ps1 -PackageList fiddler4"
+    "commandToExecute": "powershell.exe -executionpolicy bypass -File startChocolatey.ps1 -PackageList fiddler4"
 
   }
 }

--- a/Artifacts/windows-git/Artifactfile.json
+++ b/Artifacts/windows-git/Artifactfile.json
@@ -9,7 +9,7 @@
   "iconUri": "https://cdn.rawgit.com/ferventcoder/chocolatey-packages/02c21bebe5abb495a56747cbb9b4b5415c933fc0/icons/git.svg",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "powershell.exe -File startChocolatey.ps1 -PackageList git.install"
+    "commandToExecute": "powershell.exe -executionpolicy bypass -File startChocolatey.ps1 -PackageList git.install"
 
   }
 }

--- a/Artifacts/windows-mongodb/Artifactfile.json
+++ b/Artifacts/windows-mongodb/Artifactfile.json
@@ -9,7 +9,7 @@
   "iconUri": "https://cdn.rawgit.com/dtgm/chocolatey-packages/8f7101024b11677be45a74b45114000b428a9c9b/icons/mongodb.png",
   "targetOsType": "Windows",
   "runCommand": {
-      "commandToExecute": "powershell.exe -File startChocolatey.ps1 -PackageList mongodb"
+      "commandToExecute": "powershell.exe -executionpolicy bypass -File startChocolatey.ps1 -PackageList mongodb"
 
   }
 }

--- a/Artifacts/windows-node/Artifactfile.json
+++ b/Artifacts/windows-node/Artifactfile.json
@@ -11,7 +11,7 @@
   "iconUri": "https://cdn.rawgit.com/ferventcoder/chocolatey-packages/02c21bebe5abb495a56747cbb9b4b5415c933fc0/icons/nodejs.png",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "powershell.exe -File startChocolatey.ps1 -PackageList nodejs.install"
+    "commandToExecute": "powershell.exe -executionpolicy bypass -File startChocolatey.ps1 -PackageList nodejs.install"
 
   }
 }

--- a/Artifacts/windows-notepad++/Artifactfile.json
+++ b/Artifacts/windows-notepad++/Artifactfile.json
@@ -9,6 +9,6 @@
   "iconUri": "https://cdn.rawgit.com/ferventcoder/chocolatey-packages/02c21bebe5abb495a56747cbb9b4b5415c933fc0/icons/notepadplusplus.png",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "powershell.exe -File startChocolatey.ps1 -PackageList notepadplusplus.install"
+    "commandToExecute": "powershell.exe -executionpolicy bypass -File startChocolatey.ps1 -PackageList notepadplusplus.install"
   }
 }

--- a/Artifacts/windows-powershell/Artifactfile.json
+++ b/Artifacts/windows-powershell/Artifactfile.json
@@ -9,7 +9,7 @@
   "iconUri": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/Artifacts/windows-powershell/PowerShellLogo.png",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "powershell.exe -File startChocolatey.ps1 -PackageList powershell"
+    "commandToExecute": "powershell.exe -executionpolicy bypass -File startChocolatey.ps1 -PackageList powershell"
 
   }
 }

--- a/Artifacts/windows-putty/Artifactfile.json
+++ b/Artifacts/windows-putty/Artifactfile.json
@@ -9,7 +9,7 @@
   "iconUri": "",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "powershell.exe -File startChocolatey.ps1 -PackageList putty"
+    "commandToExecute": "powershell.exe -executionpolicy bypass -File startChocolatey.ps1 -PackageList putty"
 
   }
 }

--- a/Artifacts/windows-run-powershell/Artifactfile.json
+++ b/Artifacts/windows-run-powershell/Artifactfile.json
@@ -31,7 +31,7 @@
     "typeHandlerVersion": "1.3",
     "settings": {
       "fileUris": "[parameters('scriptFileUris')]",
-      "commandToExecute": "[concat('powershell.exe -File', ' ', parameters('scriptToRun'), ' ', parameters('scriptArguments'))]"
+      "commandToExecute": "[concat('powershell.exe -executionpolicy bypass -File', ' ', parameters('scriptToRun'), ' ', parameters('scriptArguments'))]"
     }
   }
 }

--- a/Artifacts/windows-sysinternals/Artifactfile.json
+++ b/Artifacts/windows-sysinternals/Artifactfile.json
@@ -9,7 +9,7 @@
   "iconUri": "",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "powershell.exe -File startChocolatey.ps1 -PackageList sysinternals"
+    "commandToExecute": "powershell.exe -executionpolicy bypass -File startChocolatey.ps1 -PackageList sysinternals"
 
   }
 }

--- a/Artifacts/windows-vscode/Artifactfile.json
+++ b/Artifacts/windows-vscode/Artifactfile.json
@@ -9,6 +9,6 @@
   "iconUri": "https://code.visualstudio.com/Content/images/vscode.ico",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "powershell.exe -File installVSCode.ps1"
+    "commandToExecute": "powershell.exe -executionpolicy bypass -File installVSCode.ps1"
   }
 }

--- a/Artifacts/windows-vso-download-and-run-script/Artifactfile.json
+++ b/Artifacts/windows-vso-download-and-run-script/Artifactfile.json
@@ -27,6 +27,6 @@
     }
   },
   "runCommand": {
-    "commandToExecute": "[concat('powershell.exe -File DownloadVsoDropAndExecuteScript.ps1', ' -accessToken ', parameters('PersonalAccessToken'), ' -buildDefinitionName ', parameters('buildDefinitionName'), ' -VsoProjectUri ', parameters('VsoProjectUri'), ' -pathToScript ', parameters('pathToScript'))]"
+    "commandToExecute": "[concat('powershell.exe -executionpolicy bypass -File DownloadVsoDropAndExecuteScript.ps1', ' -accessToken ', parameters('PersonalAccessToken'), ' -buildDefinitionName ', parameters('buildDefinitionName'), ' -VsoProjectUri ', parameters('VsoProjectUri'), ' -pathToScript ', parameters('pathToScript'))]"
   }
 }


### PR DESCRIPTION
Windows client Images need to have the execution policy bypassed to allow the installation of powershell scripts. This has been added as "-executionpolicy bypass" in the Artifact Json file after the powershell.exe. 