### PR TITLE
Add VM deletion to vms action

### DIFF
--- a/Scripts/linux/azurerest.py
+++ b/Scripts/linux/azurerest.py
@@ -76,7 +76,26 @@ class AzureRestHelper:
         verb = 'GET'
         headers = self.__getHeaders(apiVersion)
 
-        return self.__webrequest(verb, url, headers, apiVersion)
+        result, response, bodyStr = self.__webrequest(verb, url, headers, apiVersion)
+        return self.__deserializeBody(bodyStr)
+
+    def delete(self, url, apiVersion):
+        """Performs an HTTP DELETE operation
+
+        Args:
+            url (string) - the URL of the resource to delete.
+            apiVersion (string) - the API version of the resource provider used to delete the resource.
+
+        Returns:
+            A boolean value indicating whether the request was successful.
+            A response object containing the response from the DELETE request.
+        """
+        verb = 'DELETE'
+        headers = self.__getHeaders(apiVersion)
+
+        result, response, bodyStr = self.__webrequest(verb, url, headers, apiVersion)
+
+        return result, response, self.__deserializeBody(bodyStr)
 
     def post(self, url, body, apiVersion):
         """Performs an HTTP POST operation
@@ -92,7 +111,8 @@ class AzureRestHelper:
         verb = 'POST'
         headers = self.__getHeaders(apiVersion)
 
-        return self.__webrequest(verb, url, headers, apiVersion, body)
+        result, response, bodyStr = self.__webrequest(verb, url, headers, apiVersion, body)
+        return self.__deserializeBody(bodyStr)
 
     def put(self, url, body, apiVersion):
         """Performs an HTTP PUT operation
@@ -109,7 +129,23 @@ class AzureRestHelper:
         verb = 'PUT'
         headers = self.__getHeaders(apiVersion)
 
-        return self.__webrequest(verb, url, headers, apiVersion, body)
+        result, response, bodyStr = self.__webrequest(verb, url, headers, apiVersion, body)
+        return self.__deserializeBody(bodyStr)
+
+    def __deserializeBody(self, bodyStr):
+        body = None
+
+        try:
+            if self._settings.verbose:
+                print 'Response Body:'
+                print bodyStr
+
+            if bodyStr is not None:
+                body = json.loads(bodyStr)
+        except:
+            pass
+
+        return body
 
     def __getHeaders(self, apiVersion):
         coreHeaders = {
@@ -146,35 +182,13 @@ class AzureRestHelper:
             conn.request(verb, url, body, headers=headers)
 
             response = conn.getresponse()
+            bodyStr = response.read()
 
             if response.status < 200 or response.status >= 300:
                 print '{0} request failed: {1}'.format(verb, response.status)
+                return False, response, bodyStr
 
-                bodyStr = response.read()
-
-                try:
-                    body = json.loads(bodyStr)
-
-                    if self._settings.verbose:
-                        print 'Response Body:'
-                        print json.dumps(body, indent=4)
-
-                except:
-                    if self._settings.verbose:
-                        print bodyStr
-
-                return None
-
-            responseBody = response.read()
-
-            if self._settings.verbose:
-                print 'Response Body:'
-                print responseBody
-
-            if responseBody is not None:
-                return json.loads(responseBody)
-
-            return None
+            return True, response, bodyStr
 
         except httplib.HTTPException as e:
             print 'Error during {0}:{1}'.format(verb, url)

--- a/Scripts/linux/azurerest.py
+++ b/Scripts/linux/azurerest.py
@@ -111,8 +111,7 @@ class AzureRestHelper:
         verb = 'POST'
         headers = self.__getHeaders(apiVersion)
 
-        result, response, bodyStr = self.__webrequest(verb, url, headers, apiVersion, body)
-        return self.__deserializeBody(bodyStr)
+        return self.__webrequest(verb, url, headers, apiVersion, body)
 
     def put(self, url, body, apiVersion):
         """Performs an HTTP PUT operation

--- a/Scripts/linux/dtl
+++ b/Scripts/linux/dtl
@@ -95,7 +95,7 @@ class DevTestLabsMain:
 
     def __ensureAuthenticated(self):
         """Retrieves an authorization token for the principal"""
-        provider = dtlproviders.AuthorizeTokenProvider()
+        provider = dtlproviders.AuthorizeTokenProvider(self._printService)
 
         accessKey = provider.provide(self._parsedArgs)
 
@@ -144,6 +144,14 @@ class DevTestLabsMain:
 
         self._printService.verbose('Parsed argument(s):')
         self._printService.verbose(self._parsedArgs)
+
+        if self._parsedArgs.clientID is None or self._parsedArgs.secret is None or self._parsedArgs.tenant is None:
+            self._printService.error('Missing required service principal credentials')
+            sys.exit(1)
+
+        if self._parsedArgs.subscription is None:
+            self._printService.error('Missing required subscription')
+            sys.exit(1)
 
         return
 

--- a/Scripts/linux/dtlcommands.py
+++ b/Scripts/linux/dtlcommands.py
@@ -561,7 +561,7 @@ class VirtualMachinesAction:
                                dest='vmid',
                                help='The id of the virtual machine to retrieve.',
                                required=False)
-        argParser.add_argument('--d', '--delete',
+        argParser.add_argument('-d', '--delete',
                                dest='deletevm',
                                action='store_true',
                                help='Deletes the virtual machine resource from the lab.',

--- a/Scripts/linux/dtlcommands.py
+++ b/Scripts/linux/dtlcommands.py
@@ -160,7 +160,7 @@ class AuthorizeCommandAction:
         Returns:
             None
         """
-        return 'Authorizes access to Azure resources'
+        return 'Provides an access token for making custom REST calls to the lab endpoint.'
 
     def invoke(self, settings):
         """ Returns the authorization token for the current clientID.

--- a/Scripts/linux/dtlcommands.py
+++ b/Scripts/linux/dtlcommands.py
@@ -539,7 +539,7 @@ class VirtualMachinesAction:
             None
         """
 
-        return 'Lists a filtered set of virtual machines created in your lab.'
+        return 'Provides access to virtual machines in your lab.'
 
     def buildArguments(self, argParser):
         """Constructs the command-line arguments used to support this command.
@@ -560,6 +560,11 @@ class VirtualMachinesAction:
         argParser.add_argument('-vid',
                                dest='vmid',
                                help='The id of the virtual machine to retrieve.',
+                               required=False)
+        argParser.add_argument('--d', '--delete',
+                               dest='deletevm',
+                               action='store_true',
+                               help='Deletes the virtual machine resource from the lab.',
                                required=False)
         argParser.add_argument('-vb', '--verbose',
                                dest='verbose',
@@ -585,25 +590,29 @@ class VirtualMachinesAction:
         printService = dtlprint.PrintService(settings.quiet, settings.verbose)
         labSvc = dtllabservice.LabService(settings, printService)
 
-        if settings.name is not None:
-            vms = labSvc.getVirtualMachine(settings.subscription, name=settings.name)
-        elif settings.vmid is not None:
-            vms = labSvc.getVirtualMachine(settings.subscription, vmId=settings.vmid)
+        if settings.deletevm and (
+                        settings.name is not None or settings.vmid is not None) and settings.labname is not None:
+            return labSvc.deleteVirtualMachine(settings.subscription, settings.labname, settings.name, settings.vmid)
         else:
-            vms = labSvc.getVirtualMachinesForLab(settings.subscription, settings.labname)
+            if settings.name is not None:
+                vms = labSvc.getVirtualMachine(settings.subscription, name=settings.name)
+            elif settings.vmid is not None:
+                vms = labSvc.getVirtualMachine(settings.subscription, vmId=settings.vmid)
+            else:
+                vms = labSvc.getVirtualMachinesForLab(settings.subscription, settings.labname)
 
-        # Coalesce the two different results into a list of virtual machines.
-        if 'value' in vms:
-            vms = vms['value']
+            # Coalesce the two different results into a list of virtual machines.
+            if 'value' in vms:
+                vms = vms['value']
 
-        if len(vms) > 0:
-            printService.info('Virtual machine(s):')
-            printService.dumps(vms)
-        else:
-            printService.error('No virtual machines found.')
-            return 1
+            if len(vms) > 0:
+                printService.info('Virtual machine(s):')
+                printService.dumps(vms)
+            else:
+                printService.error('No virtual machines found.')
+                return 1
 
-        return 0
+            return 0
 
 
 class VirtualMachineTemplatesAction:

--- a/Scripts/linux/dtllabservice.py
+++ b/Scripts/linux/dtllabservice.py
@@ -408,24 +408,13 @@ class LabService:
                     name))
             return 1
 
-        if name is not None:
-            lab = self.getLabByName(labName)
+        vm = vms[0]
 
-            if lab is None:
-                self._printService.error('Lab {0} does not exist or is not accessible.'.format(labName))
-                return []
+        self._printService.info('Deleting virtual machine: ' + vm['name'])
 
-            labId = lab["id"]
-            rgName = self.__getResourceGroupFromLab(labId)
+        environmentId = vm['environmentId']
 
-            url = '/subscriptions/{0}/resourceGroups/{1}/providers/microsoft.devtestlab/environments/{2}?api-version={3}'.format(
-                subscriptionId,
-                rgName,
-                name,
-                self._apiVersion
-            )
-        else:
-            url = vmId + '?api-version={0}'.format(self._apiVersion)
+        url = environmentId + '?api-version={0}'.format(self._apiVersion)
 
         api = azurerest.AzureRestHelper(self._settings, self._settings.accessToken, self._host)
         success, response, responsePayload = api.delete(url, self._apiVersion)

--- a/Scripts/linux/dtllabservice.py
+++ b/Scripts/linux/dtllabservice.py
@@ -375,7 +375,7 @@ class LabService:
 
         for environment in environments:
             for vm in environment['properties']['vms']:
-                if vm[fieldName] == fieldValue:
+                if vm[fieldName].lower() == fieldValue.lower():
                     vm['environmentId'] = environment['id']
                     vms.append(vm)
                     continue

--- a/Scripts/linux/templates/201-dtl-create-vmtemplate/azuredeploy.json
+++ b/Scripts/linux/templates/201-dtl-create-vmtemplate/azuredeploy.json
@@ -38,8 +38,8 @@
       "name": "[variables('resourceName')]",
       "type": "Microsoft.DevTestLab/labs/vmtemplates",
       "properties": {
-        "createFromVmProperties": {
-          "sourceVmResourceId": "[parameters('existingVMResourceId')]"
+        "vm": {
+          "sourceVmId": "[parameters('existingVMResourceId')]"
         },
         "description": "[parameters('TemplateDescription')]",
         "imageType": "Custom",


### PR DESCRIPTION
This enables the user to delete virtual machines (and their respective environment) from the DTL CLI.  You may now include the -d or --delete switch to indicate that a vm is to be deleted.  for example:
```
dtl <credentials> vms -l mylab -n myvm -d
```