### PR TITLE
Fixes by issues caught by @DrWill-ms

### DIFF
--- a/Artifacts/windows-clone-git-repo/GitEnlister.ps1
+++ b/Artifacts/windows-clone-git-repo/GitEnlister.ps1
@@ -243,10 +243,7 @@ function GetGitRepoLeaf
     # If appended by ".git", strip that out
     if ($gitRepoLeaf -like "*.git")
     {
-        $replace = ""
-
-        # replace last occurrence
-        $gitRepoLeaf = $gitRepoLeaf -replace "(.*).git(.*)", "`$1$replace`$2"
+        $gitRepoLeaf = $gitRepoLeaf -replace "\.git$", ""
     }
 
     return $gitRepoLeaf

--- a/Artifacts/windows-clone-git-repo/GitEnlister.ps1
+++ b/Artifacts/windows-clone-git-repo/GitEnlister.ps1
@@ -24,8 +24,8 @@
     - Powershell -executionpolicy bypass -file GitEnlister.ps1 -GitRepoLocation "your repo URI" -PersonalAccessToken "access-token" -GitLocalRepoLocation "local folder location"
 
 
-    Pre-Requisites
-    ==============
+    Prerequisites
+    =============
 
     - Please ensure that this script is run elevated.
     - Please ensure that the powershell execution policy is set to unrestricted or bypass.
@@ -243,7 +243,10 @@ function GetGitRepoLeaf
     # If appended by ".git", strip that out
     if ($gitRepoLeaf -like "*.git")
     {
-        $gitRepoLeaf = $gitRepoLeaf -replace ".git", ""
+        $replace = ""
+
+        # replace last occurrence
+        $gitRepoLeaf = $gitRepoLeaf -replace "(.*).git(.*)", "`$1$replace`$2"
     }
 
     return $gitRepoLeaf
@@ -331,7 +334,7 @@ function InstallGit
     if ($false -eq ($env:Path).Contains($gitBinariesFolder))
     {
         # Add it to the path.
-        [Environment]::SetEnvironmentVariable("path", $($gitBinariesFolder + ";" + $env:Path), [System.EnvironmentVariableTarget]::Machine)    
+        [Environment]::SetEnvironmentVariable("path", $($env:Path + ";" + $gitBinariesFolder), [System.EnvironmentVariableTarget]::Machine)    
 
         WriteLog "Success."
     }


### PR DESCRIPTION
Change Description:

1: Fill spelling mistake in comments.
2: Ensuring that we strip out only the last occurrence of ".git" from the repo URI while generating the leaf token. 
3: Ensuring that the path to the git binaries folder is appended to %PATH% (and not prepended to it). 