### PR TITLE
[Bug Fix] Enabling installation of Azure SDK .Net on TH2.

### DIFF
--- a/Artifacts/windows-azuresdknet-vs2013/InstallViaWebPICmd.ps1
+++ b/Artifacts/windows-azuresdknet-vs2013/InstallViaWebPICmd.ps1
@@ -61,6 +61,9 @@ $ScriptRoot = $args[1]
 # Note: Because the $ErrorActionPreference is "Stop", this script will stop on first failure.  
 $ErrorActionPreference = "stop"
 
+# Ensure that current process can run scripts. 
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
+
 ###################################################################################################
 
 #

--- a/Artifacts/windows-azuresdknet-vs2013/StartChocolatey.ps1
+++ b/Artifacts/windows-azuresdknet-vs2013/StartChocolatey.ps1
@@ -43,7 +43,7 @@ $scriptContent = Get-Content -Path $command -Delimiter ([char]0)
 $scriptBlock = [scriptblock]::Create($scriptContent)
 
 # Run Chocolatey as the artifactInstaller user
-Enable-PSRemoting –force
+Enable-PSRemoting –force -SkipNetworkProfileCheck
 $exitCode = Invoke-Command -ScriptBlock $scriptBlock -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList @($ProductId, $PSScriptRoot)
 Disable-PSRemoting -Force
 

--- a/Artifacts/windows-azuresdknet-vs2015/InstallViaWebPICmd.ps1
+++ b/Artifacts/windows-azuresdknet-vs2015/InstallViaWebPICmd.ps1
@@ -61,6 +61,9 @@ $ScriptRoot = $args[1]
 # Note: Because the $ErrorActionPreference is "Stop", this script will stop on first failure.  
 $ErrorActionPreference = "stop"
 
+# Ensure that current process can run scripts. 
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
+
 ###################################################################################################
 
 #

--- a/Artifacts/windows-azuresdknet-vs2015/StartChocolatey.ps1
+++ b/Artifacts/windows-azuresdknet-vs2015/StartChocolatey.ps1
@@ -43,7 +43,7 @@ $scriptContent = Get-Content -Path $command -Delimiter ([char]0)
 $scriptBlock = [scriptblock]::Create($scriptContent)
 
 # Run Chocolatey as the artifactInstaller user
-Enable-PSRemoting –force
+Enable-PSRemoting –force -SkipNetworkProfileCheck
 $exitCode = Invoke-Command -ScriptBlock $scriptBlock -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList @($ProductId, $PSScriptRoot)
 Disable-PSRemoting -Force
 


### PR DESCRIPTION
Change Description:

1. Use -SkipNetworkProfileCheck switch while enabling PS remoting.
2. Using executionPolicy "bypass" to ensure that external scripts (like chocolatey installer) can be executed. 