### PR TITLE
windows-firefox icon link is busted - fixed the link in the artifact

### DIFF
--- a/Artifacts/windows-firefox/Artifactfile.json
+++ b/Artifacts/windows-firefox/Artifactfile.json
@@ -6,7 +6,7 @@
     "Windows",
     "Firefox"
   ],
-  "iconUri": "https://chocolatey.org/content/packageimages/Firefox.45.0.png",
+  "iconUri": "https://chocolatey.org/content/packageimages/Firefox.45.0.1.png",
   "targetOsType": "Windows",
     "runCommand": {
     "commandToExecute": "powershell.exe -ExecutionPolicy bypass -File startChocolatey.ps1 -PackageList firefox"


### PR DESCRIPTION
windows-firefox icon link is busted - fixed the link in the artifact to point to a valid logo link