### PR TITLE
Add support for apt-get to the Azure DevTest Labs artifact system.

### DIFF
--- a/Artifacts/linux-apt-package/Artifactfile.json
+++ b/Artifacts/linux-apt-package/Artifactfile.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
     "title": "Apt-Get",
-    "description": "Install packages on a Linux Azure DevTest Lab VM via apt-get",
+    "description": "Install packages on a Linux Azure DevTest Lab VM via the Apt package management system, using the apt-get utility. This system is the default package manager installed on Debian distributions and Debian-based distributions such as Ubuntu.",
     "tags": [
         "Package Management",
         "Apt",
@@ -22,7 +22,12 @@
             "type": "string",
             "displayName": "Run Update First",
             "defaultValue": "true",
-            "description": "Run apt-get update prior to running the full install command. Allowed values are 'true' and 'false', or blank (which will evaluate to false). Note that no additional options are passed to the update command. It is recommended for you to run update."
+            "allowEmpty": false,
+            "allowedValues": [
+                "true",
+                "false"
+            ],
+            "description": "Run apt-get update prior to running the full install command. Allowed values are 'true' and 'false'. Note that no additional options are passed to the 'apt-get update' command other than --quiet --assume-yes. It is recommended for you to set this to true and run update."
         },
         "options": {
             "type": "string",

--- a/Artifacts/linux-apt-package/Artifactfile.json
+++ b/Artifacts/linux-apt-package/Artifactfile.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
+    "title": "Apt-Get",
+    "description": "Install packages on a Linux Azure DevTest Lab VM via apt-get",
+    "tags": [
+        "Package Management",
+        "Apt",
+        "apt-get",
+        "install",
+        "Linux"
+    ],
+    "iconUri": "http://www.debian.org/favicon.ico",
+    "targetOsType": "Linux",
+    "parameters": {
+        "packages": {
+            "type": "string",
+            "displayName": "Packages",
+            "allowEmpty": false,
+            "description": "The packages to install on the VM, separated by spaces. All of the package declarations supported by apt-get are supported here as well, see http://manpages.debian.org/cgi-bin/man.cgi?query=apt-get for an in-depth look at the package specifications available."
+        },
+        "update": {
+            "type": "string",
+            "displayName": "Run Update First",
+            "defaultValue": "true",
+            "description": "Run apt-get update prior to running the full install command. Allowed values are 'true' and 'false', or blank (which will evaluate to false). Note that no additional options are passed to the update command. It is recommended for you to run update."
+        },
+        "options": {
+            "type": "string",
+            "displayName": "Additional Options",
+            "allowEmpty": true,
+            "description": "Any additional options to pass to the apt-get command line. These options will precede the install command when executed. Please see http://manpages.debian.org/cgi-bin/man.cgi?query=apt-get for an in-depth look at the options available. Note that --assume-yes and --quiet are always passed automatically."
+        }
+    },
+    "runCommand": {
+        "commandToExecute": "[concat('bash linux-apt-package.sh ', ' --update ', parameters('update'), ' --packages ', parameters('packages'), ' --options ', parameters('options'))]"
+    }
+}

--- a/Artifacts/linux-apt-package/README.md
+++ b/Artifacts/linux-apt-package/README.md
@@ -1,0 +1,86 @@
+# Linux APT Package Manager Artifact
+This Azure DevTest artifact allows the user to specify packages to install onto an Azure DevTest Lab VM
+via the apt-get package system. This artifact applies to any Linux distribution that is by default managed 
+by the Apt system (Debian, Ubuntu, and other Debian derivatives) or that has had apt set up on it.
+
+## Usage 
+The script is intended for use in the Azure DevTest Labs artifact system, and the parameters for the artifact are fed directly
+into the script. However, you can run it from any bash shell using the following format:
+
+        bash> .\linux-apt-package.sh --update (false|true) --packages pkg1 pkg2 pkg3 pkg4 --options [-asqdyfmubV] [-o=config_string] [-c=config_file] [-t=target_release] [-a=architecture]  
+
+**Where:**
+
+*update*
+
+Defaults to false, the 'update' command will be issued before the install command (and optional arguments) are run. For more detailed
+control over update arguments, the user will have to specify their own bash script and run that using the linux-bash artifact.
+
+*packages*
+
+The names of the packages to install, separated by spaces. Each package declaration follows the allowable declarations in apt-get
+install. For example, all the following would work:
+
+        pkgnm/targetdistroversion pkgnm/testing pkgnm/unstable -pkgnm +pkgnm ^pkgnmprefix.* pkgnm=version
+        
+*options*
+
+Any other valid arguments that the apt-get command accepts. Since these additional parameters allow for relatively infinite permutations
+they will likely be susceptible to failure on the images supplied by the Azure DevTest Labs. Advanced users who wish to push the limiatations
+of the extra options parameter will potentially have to experiment with certain switches to see if they work (and correct the state of
+the VM using the linux-bash artifact ahead of time if necessary).
+
+> **Note (1):** --assume-yes and --quiet are passed to both the *update* and *install* command by default (and
+> cannot be changed).  
+
+> **Note (2):**
+> Each comand line parameter has the pattern '--command values' so we can parse the required spaces. As such, there may be some unforeseen
+> limitations where double-spaces will be reduced to a single space, and other edge cases that might arise due to its use. If there is a 
+> specific use case that doesn't work within this limitation, there is the linux-bash DevTest artifact that will satisfy your needs.
+
+## Notes on apt-get
+Note that apt-get as a utility is an incredibly flexible and powerful tool. To support the use cases of the more advanced users of
+our Linux DevTest Lab VMs, a reasonable effort is made to support the nuance of the 'install' command. However, due to the vast number of 
+permutations and combinations that the command can be used to manipulate the state of a machine, we recommend that for the most advanced
+of users with specific needs use the linux-bash artifact to satisfy their specific needs.
+
+For posterity, here is the apt-get man page section on the install command at the time of authoring this artifact:
+
+---
+
+> install
+>
+> install is followed by one or more packages desired for installation or upgrading. Each package is a package name, not a fully qualified filename (for instance, in a Debian system,
+> apt-utils would be the argument provided, not apt-utils_1.0.9.8.3_amd64.deb). All packages required by the package(s) specified for installation will also be retrieved and
+> installed. The /etc/apt/sources.list file is used to locate the desired packages. If a hyphen is appended to the package name (with no intervening space), the identified package
+> will be removed if it is installed. Similarly a plus sign can be used to designate a package to install. These latter features may be used to override decisions made by apt-get's
+> conflict resolution system.
+> 
+> A specific version of a package can be selected for installation by following the package name with an equals and the version of the package to select. This will cause that version
+> to be located and selected for install. Alternatively a specific distribution can be selected by following the package name with a slash and the version of the distribution or the
+> Archive name (stable, testing, unstable).
+> 
+> Both of the version selection mechanisms can downgrade packages and must be used with care.
+> 
+> This is also the target to use if you want to upgrade one or more already-installed packages without upgrading every package you have on your system. Unlike the "upgrade" target,
+> which installs the newest version of all currently installed packages, "install" will install the newest version of only the package(s) specified. Simply provide the name of the
+> package(s) you wish to upgrade, and if a newer version is available, it (and its dependencies, as described above) will be downloaded and installed.
+> 
+> Finally, the apt_preferences(5) mechanism allows you to create an alternative installation policy for individual packages.
+> 
+> If no package matches the given expression and the expression contains one of '.', '?' or '*' then it is assumed to be a POSIX regular expression, and it is applied to all package
+> names in the database. Any matches are then installed (or removed). Note that matching is done by substring so 'lo.*' matches 'how-lo' and 'lowest'. If this is undesired, anchor the
+> regular expression with a '^' or '$' character, or create a more specific regular expression.
+> 
+[Source: debian manpages](http://manpages.debian.org/cgi-bin/man.cgi?query=apt-get)
+
+---
+
+## Tested on images:
+
+- Debian 7 "Wheezy"
+- Debian 8 "Jessie"
+- Ubuntu 12.04.5
+- Ubuntu 14.04 
+- Ubuntu 15.10
+- Ubuntu 16.04

--- a/Artifacts/linux-apt-package/README.md
+++ b/Artifacts/linux-apt-package/README.md
@@ -1,4 +1,4 @@
-# Linux APT Package Manager Artifact
+# Linux Apt Package Manager Artifact
 This Azure DevTest artifact allows the user to specify packages to install onto an Azure DevTest Lab VM
 via the apt-get package system. This artifact applies to any Linux distribution that is by default managed 
 by the Apt system (Debian, Ubuntu, and other Debian derivatives) or that has had apt set up on it.
@@ -44,35 +44,8 @@ our Linux DevTest Lab VMs, a reasonable effort is made to support the nuance of 
 permutations and combinations that the command can be used to manipulate the state of a machine, we recommend that for the most advanced
 of users with specific needs use the linux-bash artifact to satisfy their specific needs.
 
-For posterity, here is the apt-get man page section on the install command at the time of authoring this artifact:
-
----
-
-> install
->
-> install is followed by one or more packages desired for installation or upgrading. Each package is a package name, not a fully qualified filename (for instance, in a Debian system,
-> apt-utils would be the argument provided, not apt-utils_1.0.9.8.3_amd64.deb). All packages required by the package(s) specified for installation will also be retrieved and
-> installed. The /etc/apt/sources.list file is used to locate the desired packages. If a hyphen is appended to the package name (with no intervening space), the identified package
-> will be removed if it is installed. Similarly a plus sign can be used to designate a package to install. These latter features may be used to override decisions made by apt-get's
-> conflict resolution system.
-> 
-> A specific version of a package can be selected for installation by following the package name with an equals and the version of the package to select. This will cause that version
-> to be located and selected for install. Alternatively a specific distribution can be selected by following the package name with a slash and the version of the distribution or the
-> Archive name (stable, testing, unstable).
-> 
-> Both of the version selection mechanisms can downgrade packages and must be used with care.
-> 
-> This is also the target to use if you want to upgrade one or more already-installed packages without upgrading every package you have on your system. Unlike the "upgrade" target,
-> which installs the newest version of all currently installed packages, "install" will install the newest version of only the package(s) specified. Simply provide the name of the
-> package(s) you wish to upgrade, and if a newer version is available, it (and its dependencies, as described above) will be downloaded and installed.
-> 
-> Finally, the apt_preferences(5) mechanism allows you to create an alternative installation policy for individual packages.
-> 
-> If no package matches the given expression and the expression contains one of '.', '?' or '*' then it is assumed to be a POSIX regular expression, and it is applied to all package
-> names in the database. Any matches are then installed (or removed). Note that matching is done by substring so 'lo.*' matches 'how-lo' and 'lowest'. If this is undesired, anchor the
-> regular expression with a '^' or '$' character, or create a more specific regular expression.
-> 
-[Source: debian manpages](http://manpages.debian.org/cgi-bin/man.cgi?query=apt-get)
+Please see [debian manpages on apt-get](http://manpages.debian.org/cgi-bin/man.cgi?query=apt-get) for further details on what can be 
+specified for apt-get packages and additional options. 
 
 ---
 

--- a/Artifacts/linux-apt-package/linux-apt-package.sh
+++ b/Artifacts/linux-apt-package/linux-apt-package.sh
@@ -1,0 +1,133 @@
+# Script to install packages on Azure DevTest lab Linux VMs via the apt-get package management system.
+#
+# NOTE: Intended for use by the Azure DevTest Lab artifact system.
+#
+# Usage: 
+#
+# linux-apt-package.sh --update (true|false) --packages (PACKAGE-LIST) (GLOBAL|LOCAL-PATH) [ADDITIONAL-OPTIONS]
+#
+
+# Default argument values
+DEFAULT_UPDATE_MODE=0
+ARGMODE_UPDATE=update
+ARGMODE_PACKAGE=packages
+ARGMODE_OPTIONS=options
+ARGMODE_NONE=none
+REQUIRED_INSTALL_OPTIONS="--assume-yes --quiet"
+REQUIRED_UPDATE_OPTIONS="--assume-yes --quiet"
+USAGE_STRING="Usage:
+linux-apt-package.sh --update (true|false) --packages (package-list) --options (additional-options)
+
+update
+    Only specify true or false here. Default is false.
+
+packages
+    Specify packages to install separated by spaces. Follows the conventions of apt-get (see man apt-get for details).
+
+options
+    Specify any additional options you want to send to apt-get. These get injected prior to the install command.
+    
+NOTE: The additional options --quiet and --assume-yes are always used for both update and install commands executed as a result of this script.
+NOTE: No additional options are sent into the update command, if that option is specified.
+
+"
+ 
+LOGCMD='logger -i -t AZDEVTST_APTPKG --'
+which logger
+if [ $? -ne 0 ] ; then
+    LOGCMD='echo [AZDEVTST_APTPKG] '
+fi
+
+$LOGCMD "Installing apt packages. Command line given:"
+# Cannot use logger here, as the -- are interpreted by that command
+$LOGCMD "   $@"
+
+# Check for minimum number of parameters first - must be at minimum 3
+if [ $# -lt 3 ] ; then
+  $LOGCMD "ERROR: This script needs at least 3 command-line arguments, update=, packages=[somepackagename], and options=."
+  $LOGCMD "$USAGE_STRING"
+  exit 1
+fi  
+
+ARGMODE=$ARGMODE_NONE
+
+while :
+do
+    $LOGCMD "Argument mode: $ARGMODE."
+    
+    case "$1" in
+        "--$ARGMODE_UPDATE")
+            ARGMODE=$ARGMODE_UPDATE
+            DO_GLOBAL_UPDATE=$DEFAULT_UPDATE_MODE
+            shift
+            $LOGCMD "Setting argmode to $ARGMODE. Setting the update mode to default ($DO_GLOBAL_UPDATE), checking for further arguments to set update mode."
+            ;;
+        "--$ARGMODE_PACKAGE")
+            ARGMODE=$ARGMODE_PACKAGE
+            shift
+            $LOGCMD "Setting argmode to $ARGMODE. Requirement to get packages begins."
+            ;;
+        "--$ARGMODE_OPTIONS")
+            ARGMODE=$ARGMODE_OPTIONS
+            shift
+            ;;
+	"")
+	    $LOGCMD "Finished parsing through all command line arguments."
+	    break
+	    ;;
+        *)
+            case "$ARGMODE" in
+                $ARGMODE_NONE)
+                    $LOGCMD "WARNING: Parsing arguments while still in 'none' argument mode. Not supported, but we'll play along... Arg recieved is '$1'"
+                    shift
+                    ;;
+                $ARGMODE_UPDATE)
+                    $LOGCMD "Current update-before-install mode is $DO_GLOBAL_UPDATE. Argument recieved is '$1'."
+                    if [ "$1" = "true" ] || [ "$1" = "yes" ] ; then
+                        DO_GLOBAL_UPDATE=1
+                    else
+                        DO_GLOBAL_UPDATE=0
+                    fi
+                    $LOGCMD "Set update before install mode to $DO_GLOBAL_UPDATE."
+                    shift
+                    ;;
+                $ARGMODE_PACKAGE)
+                    $LOGCMD "Current packages set to install are '$INSTALL_PACKAGES', adding argument received '$1'"
+                    INSTALL_PACKAGES="$INSTALL_PACKAGES $1"
+                    $LOGCMD "...packages to install is now '$INSTALL_PACKAGES'"
+                    shift
+                    ;;
+                $ARGMODE_OPTIONS)
+                    $LOGCMD "Current additional options set are $ADDITIONAL_OPTIONS, adding argument received '$1'"
+                    $ADDITIONAL_OPTIONS = "$ADDITIONAL_OPTIONS $1"
+                    $LOGCMD "...additional options is now '$ADDITIONAL_OPTIONS'"
+                    shift
+                    ;;
+                *)
+                    $LOGCMD "ERROR: Got into argument mode '$ARGMODE' somehow, not supported! Argument received is '$1'"
+                    $LOGCMD "$USAGE_STRING"
+                    exit 1
+                    ;;
+            esac
+            ;;
+    esac
+done
+
+set -e
+
+if [ $DO_GLOBAL_UPDATE -eq 1 ] ; then
+    $LOGCMD "Updating the system using apt-get update. Command line being used is: 'apt-get $REQUIRED_UPDATE_OPTIONS update'."
+    apt-get $REQUIRED_UPDATE_OPTIONS update
+    $LOGCMD "Update COMPLETED."
+else
+    $LOGCMD "Skipping apt-get update prior to package install."
+fi
+
+$LOGCMD "Installing packages using apt-get, using command line:"
+$LOGCMD "  apt-get $ADDITIONAL_OPTIONS $REQUIRED_INSTALL_OPTIONS install $INSTALL_PACKAGES"
+apt-get $ADDITIONAL_OPTIONS $REQUIRED_INSTALL_OPTIONS install $INSTALL_PACKAGES
+
+set +e
+
+$LOGCMD "Done installing packages"
+


### PR DESCRIPTION
# ALM Rangers Artifact: Apt-Get #
## Package Management for Debian Based Systems ##

Exposes the natural package management system for Debian-based systems to the Azure DevTest Labs users. 

Now users can install whatever software they wish via apt-get in a way that is natural to people familiar with Debian and its derivative distributions.

Please see README.md for list of supported distributions and usage.