### PR TITLE
Add support for yum to the Azure DevTest Labs artifact system.

### DIFF
--- a/Artifacts/linux-yum-package/Artifactfile.json
+++ b/Artifacts/linux-yum-package/Artifactfile.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
-    "title": "Yum",
+    "title": "YUM",
     "description": "Install packages on a Linux Azure DevTest Lab VM via YUM",
     "tags": [
         "Package Management",
-        "Yum",
+        "YUM",
         "install",
         "Linux"
     ],
@@ -15,19 +15,24 @@
             "type": "string",
             "displayName": "Packages",
             "allowEmpty": false,
-            "description": "The packages to install on the VM, separated by spaces. All of the package declarations supported by yum are supported here as well, see http://man7.org/linux/man-pages/man8/yum.8.html for an in-depth look at the package specifications available."
+            "description": "The packages to install on the VM, separated by spaces. All of the package declarations supported by YUM are supported here as well, see http://man7.org/linux/man-pages/man8/yum.8.html for an in-depth look at the package specifications available."
         },
         "update": {
             "type": "string",
             "displayName": "Run Update First",
             "defaultValue": "true",
-            "description": "Run yum update prior to running the full install command. Allowed values are 'true' and 'false', or blank (which will evaluate to false). Note that no additional options are passed to the update command."
+            "allowEmpty": false,
+            "allowedValues": [
+                "true",
+                "false"
+            ],
+            "description": "Run YUM update prior to running the full install command. Allowed values are 'true' and 'false'. Note that no additional options are passed to the update command."
         },
         "options": {
             "type": "string",
             "displayName": "Additional Options",
             "allowEmpty": true,
-            "description": "Any additional options to pass to the yum command line. These options will precede the install command when executed. Please see http://man7.org/linux/man-pages/man8/yum.8.html for an in-depth look at the options available. Note that --assumeyes and --quiet are always passed automatically."
+            "description": "Any additional options to pass to the YUM command line. These options will precede the install command when executed. Please see http://man7.org/linux/man-pages/man8/yum.8.html for an in-depth look at the options available. Note that --assumeyes and --quiet are always passed automatically."
         }
     },
     "runCommand": {

--- a/Artifacts/linux-yum-package/Artifactfile.json
+++ b/Artifacts/linux-yum-package/Artifactfile.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
+    "title": "Yum",
+    "description": "Install packages on a Linux Azure DevTest Lab VM via YUM",
+    "tags": [
+        "Package Management",
+        "Yum",
+        "install",
+        "Linux"
+    ],
+    "iconUri": "http://fedoraproject.org/w/uploads/7/77/Echo-package-48px.png",
+    "targetOsType": "Linux",
+    "parameters": {
+        "packages": {
+            "type": "string",
+            "displayName": "Packages",
+            "allowEmpty": false,
+            "description": "The packages to install on the VM, separated by spaces. All of the package declarations supported by yum are supported here as well, see http://man7.org/linux/man-pages/man8/yum.8.html for an in-depth look at the package specifications available."
+        },
+        "update": {
+            "type": "string",
+            "displayName": "Run Update First",
+            "defaultValue": "true",
+            "description": "Run yum update prior to running the full install command. Allowed values are 'true' and 'false', or blank (which will evaluate to false). Note that no additional options are passed to the update command."
+        },
+        "options": {
+            "type": "string",
+            "displayName": "Additional Options",
+            "allowEmpty": true,
+            "description": "Any additional options to pass to the yum command line. These options will precede the install command when executed. Please see http://man7.org/linux/man-pages/man8/yum.8.html for an in-depth look at the options available. Note that --assumeyes and --quiet are always passed automatically."
+        }
+    },
+    "runCommand": {
+        "commandToExecute": "[concat('bash linux-yum-package.sh', ' --update ', parameters('update'), ' --packages ', parameters('packages'), ' --options ', parameters('options'))]"
+    }
+}

--- a/Artifacts/linux-yum-package/README.md
+++ b/Artifacts/linux-yum-package/README.md
@@ -1,13 +1,13 @@
-# Linux Yum Package Manager Artifact
+# Linux YUM Package Manager Artifact
 This Azure DevTest artifact allows the user to specify packages to install onto their Azure DevTest Lab VM
-via the Yum package system. This artifact applies to any Linux distribution that is by default managed by 
-the RPM/Yum system (Red Hat, CentOS, and other Red Hat Linux derivatives).
+via the YUM package system. This artifact applies to any Linux distribution that is by default managed by 
+the RPM/YUM system (Red Hat, CentOS, and other Red Hat Linux derivatives).
 
 ## Usage 
 The script is intended for use in the Azure DevTest Labs artifact system, and the parameters for the artifact are fed directly
 into the script. However, you can run it from any bash shell using the following format:
 
-        bash> .\linux-yum-package.sh --update (false|true) --packages pkg1 pkg2 pkg3 pkg4 --options *[yum options for install command]*  
+        bash> .\linux-yum-package.sh --update (false|true) --packages pkg1 pkg2 pkg3 pkg4 --options *[YUM options for install command]*  
 
 **Where:**
 
@@ -18,14 +18,14 @@ control over update arguments, the user will have to specify their own bash scri
 
 *packages*
 
-The names of the packages to install, separated by spaces. Each package declaration follows the allowable declarations in yum
+The names of the packages to install, separated by spaces. Each package declaration follows the allowable declarations in YUM
 install. For example, all the following would work:
 
         pkgnm pkgnm-ver pkgnm-ver-rel.arch -pkgnm @groupnm ^@envgroupname
         
 *options*
 
-Any other valid arguments that the yum install command accepts. Since these additional parameters allow for relatively infinite permutations
+Any other valid arguments that the YUM install command accepts. Since these additional parameters allow for relatively infinite permutations
 they will likely be susceptible to failure on the images supplied by the Azure DevTest Labs. Advanced users who wish to push the limiatations
 of the extra options parameter will potentially have to experiment with certain switches to see if they work (and correct the state of
 the VM using the linux-bash artifact ahead of time if necessary).
@@ -38,66 +38,13 @@ the VM using the linux-bash artifact ahead of time if necessary).
 > limitations where double-spaces will be reduced to a single space, and other edge cases that might arise due to its use. If there is a 
 > specific use case that doesn't work within this limitation, there is the linux-bash DevTest artifact that will satisfy your needs.
 
-## Notes on yum
-Note that yum as a utility is an incredibly flexible and powerful tool. To support the use cases of the more advanced users of
+## Notes on YUM
+Note that YUM as a utility is an incredibly flexible and powerful tool. To support the use cases of the more advanced users of
 our Linux DevTest Lab VMs, a reasonable effort has been made to support the nuance of the 'install' command. However, due to the vast number of 
 permutations and combinations that the command can be used to manipulate the state of a machine, we recommend that for the most advanced
 of users with specific needs use the linux-bash artifact to satisfy their specific needs.
 
-For posterity, here is the yum man page section on the install command at the time of authoring this artifact:
-
----
-
-        install
-              Is used to install the latest version of a package or group of
-              packages while ensuring that all dependencies are satisfied.
-              (See Specifying package names for more information) If no
-              package matches the given package name(s), they are assumed to
-              be a shell glob and any matches are then installed. If the
-              name starts with @^ then it is treated as an environment group
-              (group install @^foo), an @ character and it's treated as a
-              group (plain group install).
-
-              If the name starts with a "-" character, then a search is done
-              within the transaction and any matches are removed. Note that
-              Yum options use the same syntax and it may be necessary to use
-              "--" to resolve any possible conflicts.
-
-              If the name is a file, then install works like localinstall.
-              If the name doesn't match a package, then package "provides"
-              are searched (e.g. "_sqlitecache.so()(64bit)") as are
-              filelists (Eg. "/usr/bin/yum"). Also note that for filelists,
-              wildcards will match multiple packages.
-
-              Because install does a lot of work to make it as easy as
-              possible to use, there are also a few specific install
-              commands "install-n", "install-na" and "install-nevra". These
-              only work on package names, and do not process wildcards etc.
-        
-        ...
-        
-        SPECIFYING PACKAGE NAMES
-
-        A package can be referred to for install, update, remove, list, info
-        etc with any of the following as well as globs of any of the
-        following:
-
-              name
-              name.arch
-              name-ver
-              name-ver-rel
-              name-ver-rel.arch
-              name-epoch:ver-rel.arch
-              epoch:name-ver-rel.arch
-
-              For example: yum remove kernel-2.4.1-10.i686
-                   this will remove this specific kernel-ver-rel.arch.
-
-              Or:          yum list available 'foo*'
-                   will list all available packages that match 'foo*'. (The
-              single quotes will keep your shell from expanding the globs.)
-
-[Source: linux manpages (man7)](http://man7.org/linux/man-pages/man8/yum.8.html)
+See [linux manpages for YUM (man7)](http://man7.org/linux/man-pages/man8/yum.8.html) for further information.
 
 ---
 

--- a/Artifacts/linux-yum-package/README.md
+++ b/Artifacts/linux-yum-package/README.md
@@ -1,0 +1,114 @@
+# Linux Yum Package Manager Artifact
+This Azure DevTest artifact allows the user to specify packages to install onto their Azure DevTest Lab VM
+via the Yum package system. This artifact applies to any Linux distribution that is by default managed by 
+the RPM/Yum system (Red Hat, CentOS, and other Red Hat Linux derivatives).
+
+## Usage 
+The script is intended for use in the Azure DevTest Labs artifact system, and the parameters for the artifact are fed directly
+into the script. However, you can run it from any bash shell using the following format:
+
+        bash> .\linux-yum-package.sh --update (false|true) --packages pkg1 pkg2 pkg3 pkg4 --options *[yum options for install command]*  
+
+**Where:**
+
+*update*
+
+Defaults to false, the 'update' command will be issued before the install command (and optional arguments) are run. For more detailed
+control over update arguments, the user will have to specify their own bash script and run that using the linux-bash artifact.
+
+*packages*
+
+The names of the packages to install, separated by spaces. Each package declaration follows the allowable declarations in yum
+install. For example, all the following would work:
+
+        pkgnm pkgnm-ver pkgnm-ver-rel.arch -pkgnm @groupnm ^@envgroupname
+        
+*options*
+
+Any other valid arguments that the yum install command accepts. Since these additional parameters allow for relatively infinite permutations
+they will likely be susceptible to failure on the images supplied by the Azure DevTest Labs. Advanced users who wish to push the limiatations
+of the extra options parameter will potentially have to experiment with certain switches to see if they work (and correct the state of
+the VM using the linux-bash artifact ahead of time if necessary).
+
+> **Note (1):** --assumeyes and --quiet are passed to both the *update* and *install* command by default (and
+> cannot be changed).  
+
+> **Note (2):**
+> Each comand line parameter has the pattern '--command values' so we can parse the required spaces. As such, there may be some unforeseen
+> limitations where double-spaces will be reduced to a single space, and other edge cases that might arise due to its use. If there is a 
+> specific use case that doesn't work within this limitation, there is the linux-bash DevTest artifact that will satisfy your needs.
+
+## Notes on yum
+Note that yum as a utility is an incredibly flexible and powerful tool. To support the use cases of the more advanced users of
+our Linux DevTest Lab VMs, a reasonable effort has been made to support the nuance of the 'install' command. However, due to the vast number of 
+permutations and combinations that the command can be used to manipulate the state of a machine, we recommend that for the most advanced
+of users with specific needs use the linux-bash artifact to satisfy their specific needs.
+
+For posterity, here is the yum man page section on the install command at the time of authoring this artifact:
+
+---
+
+        install
+              Is used to install the latest version of a package or group of
+              packages while ensuring that all dependencies are satisfied.
+              (See Specifying package names for more information) If no
+              package matches the given package name(s), they are assumed to
+              be a shell glob and any matches are then installed. If the
+              name starts with @^ then it is treated as an environment group
+              (group install @^foo), an @ character and it's treated as a
+              group (plain group install).
+
+              If the name starts with a "-" character, then a search is done
+              within the transaction and any matches are removed. Note that
+              Yum options use the same syntax and it may be necessary to use
+              "--" to resolve any possible conflicts.
+
+              If the name is a file, then install works like localinstall.
+              If the name doesn't match a package, then package "provides"
+              are searched (e.g. "_sqlitecache.so()(64bit)") as are
+              filelists (Eg. "/usr/bin/yum"). Also note that for filelists,
+              wildcards will match multiple packages.
+
+              Because install does a lot of work to make it as easy as
+              possible to use, there are also a few specific install
+              commands "install-n", "install-na" and "install-nevra". These
+              only work on package names, and do not process wildcards etc.
+        
+        ...
+        
+        SPECIFYING PACKAGE NAMES
+
+        A package can be referred to for install, update, remove, list, info
+        etc with any of the following as well as globs of any of the
+        following:
+
+              name
+              name.arch
+              name-ver
+              name-ver-rel
+              name-ver-rel.arch
+              name-epoch:ver-rel.arch
+              epoch:name-ver-rel.arch
+
+              For example: yum remove kernel-2.4.1-10.i686
+                   this will remove this specific kernel-ver-rel.arch.
+
+              Or:          yum list available 'foo*'
+                   will list all available packages that match 'foo*'. (The
+              single quotes will keep your shell from expanding the globs.)
+
+[Source: linux manpages (man7)](http://man7.org/linux/man-pages/man8/yum.8.html)
+
+---
+
+## Tested on images:
+ - CentOS 6.5
+ - CentOS 6.7
+ - RHEL 7.2
+ - RHEL 6.7
+
+*Working, but problems (with workarounds) exist:*    
+ - CentOS 6.6 - Works without update.
+ - CentOS 7.0 - Works without update.
+ - CentOS 7.1 - Works without update.
+ - CentOS 7.2 - Works without update.

--- a/Artifacts/linux-yum-package/linux-yum-package.sh
+++ b/Artifacts/linux-yum-package/linux-yum-package.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# Script to install packages on Azure DevTest lab Linux VMs via the yum package management system.
+#
+# NOTE: Intended for use by the Azure DevTest Lab artifact system.
+#
+# Usage: 
+#
+# linux-yum-package.sh --update (true|false) --packages (PACKAGE-LIST) --options [ADDITIONAL-OPTIONS]
+#
+
+# Default argument values
+DEFAULT_UPDATE_MODE=0
+ARGMODE_UPDATE=update
+ARGMODE_PACKAGE=packages
+ARGMODE_OPTIONS=options
+ARGMODE_NONE=none
+REQUIRED_INSTALL_OPTIONS="--assumeyes --quiet"
+REQUIRED_UPDATE_OPTIONS="--assumeyes --quiet"
+USAGE_STRING="Usage:
+linux-yum-package.sh --update (true|false) --packages (package-list) --options (additional-options)
+
+update
+    Only specify true or false here. Default is false.
+
+packages
+    Specify packages to install separated by spaces. Follows the conventions of yum (see man yum for details).
+
+options
+    Specify any additional options you want to send to yum. These get injected prior to the install command.
+    
+NOTE: The additional options '$REQUIRED_INSTALL_OPTIONS' are always used for both update and install commands executed as a result of this script.
+NOTE: No additional options are sent into the update command, if that option is specified.
+
+"
+
+LOGCMD='logger -i -t AZDEVTST_YUMPKG --'
+which logger
+if [ $? -ne 0 ] ; then
+    LOGCMD='echo [AZDEVTST_YUMPKG] '
+fi
+
+$LOGCMD "Installing packages. Command line given:"
+$LOGCMD "   $@"
+
+# Check for minimum number of parameters first - must be at minimum 3
+if [ $# -lt 3 ] ; then
+  $LOGCMD "ERROR: This script needs at least 3 command-line arguments, update=, packages=[somepackagename], and options=."
+  $LOGCMD "$USAGE_STRING"
+  exit 1
+fi  
+
+ARGMODE=$ARGMODE_NONE
+
+while :
+do
+    $LOGCMD "Argument mode: $ARGMODE. Argument being processed is '$1'"
+    
+    case "$1" in
+        "--$ARGMODE_UPDATE")
+            ARGMODE=$ARGMODE_UPDATE
+            DO_GLOBAL_UPDATE=$DEFAULT_UPDATE_MODE
+            shift
+            $LOGCMD "Setting argmode to $ARGMODE. Setting the update mode to default ($DO_GLOBAL_UPDATE), checking for further arguments to set update mode."
+            ;;
+        "--$ARGMODE_PACKAGE")
+            ARGMODE=$ARGMODE_PACKAGE
+            shift
+            $LOGCMD "Setting argmode to $ARGMODE. Requirement to get packages begins."
+            ;;
+        "--$ARGMODE_OPTIONS")
+            ARGMODE=$ARGMODE_OPTIONS
+            shift
+            ;;
+        "")
+	        $LOGCMD "Finished parsing through all command line arguments."
+	        break
+	        ;;
+        *)
+            case "$ARGMODE" in
+                $ARGMODE_NONE)
+                    $LOGCMD "WARNING: Parsing arguments while still in 'none' argument mode. Not supported, but we'll play along... Arg recieved is '$1'"
+                    shift
+                    ;;
+                $ARGMODE_UPDATE)
+                    $LOGCMD "Current update-before-install mode is $DO_GLOBAL_UPDATE. Argument recieved is '$1'."
+                    if [ "$1" = "true" ] || [ "$1" = "yes" ] ; then
+                        DO_GLOBAL_UPDATE=1
+                    else
+                        DO_GLOBAL_UPDATE=0
+                    fi
+                    $LOGCMD "Set update before install mode to $DO_GLOBAL_UPDATE."
+                    shift
+                    ;;
+                $ARGMODE_PACKAGE)
+                    $LOGCMD "Current packages set to install are '$INSTALL_PACKAGES', adding argument received '$1'"
+                    INSTALL_PACKAGES="$INSTALL_PACKAGES $1"
+                    $LOGCMD "...packages to install is now '$INSTALL_PACKAGES'"
+                    shift
+                    ;;
+                $ARGMODE_OPTIONS)
+                    $LOGCMD "Current additional options set are $ADDITIONAL_OPTIONS, adding argument received '$1'"
+                    $ADDITIONAL_OPTIONS = "$ADDITIONAL_OPTIONS $1"
+                    $LOGCMD "...additional options is now '$ADDITIONAL_OPTIONS'"
+                    shift
+                    ;;
+                *)
+                    $LOGCMD "ERROR: Got into argument mode '$ARGMODE' somehow, not supported! Argument received is '$1'"
+                    $LOGCMD "$USAGE_STRING"
+                    exit 1
+                    ;;
+            esac
+            ;;
+    esac
+done
+
+set -e
+
+if [ $DO_GLOBAL_UPDATE -eq 1 ] ; then
+    $LOGCMD "Updating the system using yum update. Command line being used is: 'yum $REQUIRED_UPDATE_OPTIONS update'."
+    yum $REQUIRED_UPDATE_OPTIONS update
+    $LOGCMD "Update COMPLETED."
+else
+    $LOGCMD "Skipping yum update prior to package install."
+fi
+
+$LOGCMD "Installing packages using yum, using command line:"
+$LOGCMD "  yum $ADDITIONAL_OPTIONS $REQUIRED_INSTALL_OPTIONS install $INSTALL_PACKAGES"
+yum $ADDITIONAL_OPTIONS $REQUIRED_INSTALL_OPTIONS install $INSTALL_PACKAGES
+
+set +e
+
+$LOGCMD "Done installing packages"


### PR DESCRIPTION
# ALM Rangers Artifact: Apt-Get #
## Package Management for Debian Based Systems ##

Exposes the natural package management system for Red Hat-based systems to the Azure DevTest Labs users.

Now users can install whatever software they wish via yum in a way that is natural to people familiar with Red Hat and its derivative distributions (CentOS).

Please see README.md for list of supported distributions and usage.

> NOTE: There is an issue when using the Yum artifact with many of the CentOS images when update is selected. An issue will be pushed shortly to highlight this to the Azure DevTest Labs team. (EDIT: Issue has been raised as #75 )
