### PR TITLE
Add support for npm package installations to Azure DevTest Labs artifacts

### DIFF
--- a/Artifacts/linux-npm-package/Artifactfile.json
+++ b/Artifacts/linux-npm-package/Artifactfile.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
     "title": "NPM Package",
-    "description": "Install NPM packages on linux using the Node Package Manager.",
+    "description": "Install NPM packages on Linux using the Node Package Manager.",
     "tags": [
         "NPM",
         "Linux",
@@ -20,14 +20,14 @@
         "packages": {
             "type": "string",
             "displayName": "Packages to Install",
-            "description": "The package names you wish to have installed via NPM, separated by commas. The packages will be installed globally. If NPM is not yet on the system, it also will be installed. You can find NPM package names in the index found at https://www.npmjs.com. All npm install commands are supported, however if a git/bitbucket/gist scope is given then you must have installed the git artifact prior to this npm package artifact."
+            "description": "The package names you wish to have installed via NPM, separated by spaces. You can find NPM package names in the index found at https://www.npmjs.com. All npm install commands are supported, however if a Git/bitbucket/gist scope is given then you must have installed the Git artifact prior to this NPM package artifact."
         },
         "otherOptions": {
             "type": "string",
             "displayName": "Additional Options",
             "allowEmpty": true,
             "defaultValue": "",
-            "description": "Any additional options you wish to supply on the command line. See npm install man page here: https://docs.npmjs.com/cli/install"
+            "description": "Any additional options you wish to supply on the command line. See NPM install man page here: https://docs.npmjs.com/cli/install"
         }
     },
     "runCommand": {

--- a/Artifacts/linux-npm-package/Artifactfile.json
+++ b/Artifacts/linux-npm-package/Artifactfile.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
+    "title": "NPM Package",
+    "description": "Install NPM packages on linux using the Node Package Manager.",
+    "tags": [
+        "NPM",
+        "Linux",
+        "Packages"
+    ],
+    "iconUri": "https://www.npmjs.com/favicon.ico",
+    "targetOsType": "Linux",
+    "parameters": {
+        "installLocation": {
+            "type": "string",
+            "displayName": "Install Location",
+            "defaultValue": "/var/tmp",
+            "allowEmpty": false,
+            "description": "The local path to install the package to or the keyword 'global' to install the package(s) globally instead."
+        },
+        "packages": {
+            "type": "string",
+            "displayName": "Packages to Install",
+            "description": "The package names you wish to have installed via NPM, separated by commas. The packages will be installed globally. If NPM is not yet on the system, it also will be installed. You can find NPM package names in the index found at https://www.npmjs.com. All npm install commands are supported, however if a git/bitbucket/gist scope is given then you must have installed the git artifact prior to this npm package artifact."
+        },
+        "otherOptions": {
+            "type": "string",
+            "displayName": "Additional Options",
+            "allowEmpty": true,
+            "defaultValue": "",
+            "description": "Any additional options you wish to supply on the command line. See npm install man page here: https://docs.npmjs.com/cli/install"
+        }
+    },
+    "runCommand": {
+      "commandToExecute": "[concat('sh linux-npm-package.sh', ' --packages ', parameters('packages'), ' --install-to ', parameters('installLocation'), ' --options ', parameters('otherOptions'))]"
+  }
+}

--- a/Artifacts/linux-npm-package/README.md
+++ b/Artifacts/linux-npm-package/README.md
@@ -33,7 +33,7 @@ value can be any valid path (ie. /var/tmp/dev) to install the npm packages into.
 *options*
 
 Any other valid arguments that the npm-install command accepts. Since these additional parameters allow for relatively infinite permutations
-they will likely be susceptible to failure on the images supplied by the Azure DevTest Labs. Advanced users who wish to push the limiatations
+they will likely be susceptible to failure on the images supplied by the Azure DevTest Labs. Advanced users who wish to push the limitations
 of the extra options parameter will potentially have to experiment with certain switches to see if they work (and correct the state of
 the VM using the linux-bash artifact ahead of time if necessary).
 

--- a/Artifacts/linux-npm-package/README.md
+++ b/Artifacts/linux-npm-package/README.md
@@ -1,0 +1,45 @@
+# NPM Packages #
+## Azure DevTest Labs Artifact ##
+
+### Linux NPM Package Manager Artifact ###
+This Azure DevTest artifact allows the user to specify packages to install onto an Azure DevTest Lab VM
+via the npm package system. The npm package manager must first be installed on the system in some other 
+manner, one can use the bash script artifact, the apt artifact for debian-based systems, or the yum artifact
+for redhat-based systems.
+
+### Usage ###
+The script is intended for use in the Azure DevTest Labs artifact system, and the parameters for the artifact are fed directly
+into the script. However, you can run it from any bash shell using the following format:
+
+        bash> .\linux-npm-package.sh -packages (PACKAGE-LIST) --install-to (global|/path/to) --options [ADDITIONAL-OPTIONS]
+
+**Where:**
+
+*packages*
+
+The names of the packages to install, separated by spaces. Each package declaration follows the allowable declarations in npm
+install. For example, all the following would work:
+
+        pkgnm githubname/reponame @myorg/privatepackage
+        
+...please see the [man page for npm](https://docs.npmjs.com/cli/install) for a description of all package reference strings
+    
+*install-to*
+
+Defaults to global, the 'install-to' parameter tells npm where to install the named packages. This can be the keyword 'global' 
+or left blank (default is global) to install to the global location (typically /usr/lib/node_modules on a Linux system). Or the
+value can be any valid path (ie. /var/tmp/dev) to install the npm packages into.
+
+*options*
+
+Any other valid arguments that the npm-install command accepts. Since these additional parameters allow for relatively infinite permutations
+they will likely be susceptible to failure on the images supplied by the Azure DevTest Labs. Advanced users who wish to push the limiatations
+of the extra options parameter will potentially have to experiment with certain switches to see if they work (and correct the state of
+the VM using the linux-bash artifact ahead of time if necessary).
+
+---
+
+## Tested on images:
+
+- Ubuntu 16.04
+- RHEL 7.2

--- a/Artifacts/linux-npm-package/linux-npm-package.sh
+++ b/Artifacts/linux-npm-package/linux-npm-package.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+#
+# Script to install NPM packages on Azure DevTest lab VMs.
+#
+# For each package requested to install, runs the currently installed
+# npm to actually perform the install. Every package requested is either
+# installed to the global system or to a specific local path on the VM.
+#
+# NOTE: Intended for use by the Azure DevTest Lab artifact system.
+#
+# Usage: 
+#
+# linux-npm-package.sh -packages (PACKAGE-LIST) --install-to (true|false) --options [ADDITIONAL-OPTIONS]
+#
+
+# Constants:
+DEFAULT_INSTALL_GLOBAL=1
+GLOBAL_SWITCH=""
+INSTALL_TO="/var/tmp"
+ARGMODE_INSTALLTO=install-to
+ARGMODE_PACKAGE=packages
+ARGMODE_OPTIONS=options
+ARGMODE_NONE=none
+REQUIRED_INSTALL_OPTIONS=""
+USAGE_STRING="Usage:
+linux-npm-package.sh --packages (package-list) --install-global (boolean) --options (additional-options)
+
+packages
+    Specify packages to install separated by spaces.
+
+install-to 
+    Path to install the packages to. If this isn't specified (or is given as an empty string/blank) then the packages
+    are installed globally. Also, if the keyword 'global' is specified, the packages are installed globally as well.
+    
+options
+    Specify any additional options you want to send to npm. All of these are appended to the end of the entire npm command.
+    
+NOTE: The additional options --quiet and --assume-yes are always used for both update and install commands executed as a result of this script.
+NOTE: No additional options are sent into the update command, if that option is specified.
+
+"
+
+LOGCMD='logger -i -t AZDEVTST_NPMPKG --'
+which logger
+if [ $? -ne 0 ] ; then
+    LOGCMD=echo
+fi
+
+$LOGCMD "Installing packages. Command line given:"
+$LOGCMD "   $@"
+
+# Check for minimum number of parameters first - must be at minimum 3
+if [ $# -lt 3 ] ; then
+  $LOGCMD "ERROR: This script needs at least 3 command-line arguments, update, packages, and options."
+  $LOGCMD "$USAGE_STRING"
+  exit 1
+fi
+
+which npm
+if [ $? -ne 0 ] ; then
+    $LOGCMD "ERROR: No npm found in path. Please install npm via apt, yum, or whichever package management system is available and re-run this artifact."
+    exit 1
+fi
+
+ARGMODE=$ARGMODE_NONE
+
+while :
+do
+    $LOGCMD "Argument mode: $ARGMODE. Argument being processed is '$1'"
+    
+    case "$1" in
+        "--$ARGMODE_INSTALLTO")
+            ARGMODE=$ARGMODE_INSTALLTO
+            INSTALL_GLOBAL=$DEFAULT_INSTALL_GLOBAL
+            shift
+            $LOGCMD "Setting argmode to $ARGMODE. Setting the $ARGMODE_INSTALLTO mode to default ($INSTALL_GLOBAL), checking for further arguments to set $ARGMODE_INSTALLTO mode."
+            ;;
+        "--$ARGMODE_PACKAGE")
+            ARGMODE=$ARGMODE_PACKAGE
+            shift
+            $LOGCMD "Setting argmode to $ARGMODE. Requirement to get packages begins."
+            ;;
+        "--$ARGMODE_OPTIONS")
+            ARGMODE=$ARGMODE_OPTIONS
+            shift
+            ;;
+        "")
+	        $LOGCMD "Finished parsing through all command line arguments."
+	        break
+	        ;;
+        *)
+            case "$ARGMODE" in
+                $ARGMODE_NONE)
+                    $LOGCMD "WARNING: Parsing arguments while still in 'none' argument mode. Not supported, but we'll play along... Arg recieved is '$1'"
+                    shift
+                    ;;
+                $ARGMODE_INSTALLTO)
+                    $LOGCMD "Current $ARGMODE mode is $INSTALL_GLOBAL. Argument recieved is '$1'."
+                    if [ "$1" = "global" ] ; then
+                        INSTALL_GLOBAL=1
+                    else
+                        INSTALL_GLOBAL=0
+                        INSTALL_TO="$1"
+                        $LOGCMD "Setting install location to specified path '$INSTALL_TO'"
+                    fi
+                    $LOGCMD "Set update before install mode to $INSTALL_GLOBAL."
+                    shift
+                    ;;
+                $ARGMODE_PACKAGE)
+                    $LOGCMD "Current packages set to install are '$INSTALL_PACKAGES', adding argument received '$1'"
+                    INSTALL_PACKAGES="$INSTALL_PACKAGES $1"
+                    $LOGCMD "...packages to install is now '$INSTALL_PACKAGES'"
+                    shift
+                    ;;
+                $ARGMODE_OPTIONS)
+                    $LOGCMD "Current additional options set are $ADDITIONAL_OPTIONS, adding argument received '$1'"
+                    ADDITIONAL_OPTIONS="$ADDITIONAL_OPTIONS $1"
+                    $LOGCMD "...additional options is now '$ADDITIONAL_OPTIONS'"
+                    shift
+                    ;;
+                *)
+                    $LOGCMD "ERROR: Got into argument mode '$ARGMODE' somehow, not supported! Argument received is '$1'"
+                    $LOGCMD "$USAGE_STRING"
+                    exit 1
+                    ;;
+            esac
+            ;;
+    esac
+done
+$LOGCMD "Got Arguments: Install Globally='$INSTALL_GLOBAL' InstallLoc='$INSTALL_TO' Install Packages='$INSTALL_PACKAGES' Options='$ADDITIONAL_OPTIONS'"
+
+# Determine if the package install is for global or local. If local, ensure
+# the local path is available
+if [ $INSTALL_GLOBAL -ne 1 ] ; then
+
+    $LOGCMD "Testing if the local installation path '$INSTALL_TO' exists..."
+    
+    if [ ! -d "$INSTALL_TO" ] ; then
+        $LOGCMD "...it does not, creating it:"
+        
+        mkdir -p "$INSTALL_TO"
+        if [ $? -ne 0 ] ; then
+            
+            $LOGCMD "Could not make folder '$INSTALL_TO'. Failing process."
+            
+        fi
+    else
+    
+        $LOGCMD "...it does exist."
+    
+    fi
+    
+    cd "$INSTALL_TO"
+
+else
+
+    GLOBAL_SWITCH="--global"
+    
+fi
+
+# For each package named in the parameter list, install the package and log the 
+# install command line for potential diagnosing later
+arr=$(echo $PACKAGE_LIST | tr "," "\n")
+
+set -e
+
+$LOGCMD "Installing packages '$INSTALL_PACKAGES', using command line:"
+$LOGCMD "npm install $GLOBAL_SWITCH \"$INSTALL_PACKAGES\" $ADDITIONAL_OPTIONS"
+    
+npm install $GLOBAL_SWITCH $INSTALL_PACKAGES $ADDITIONAL_OPTIONS
+    
+set +e
+
+$LOGCMD "Done installing npm packages '$INSTALL_PACKAGES'."


### PR DESCRIPTION
# ALM Rangers Artifact: NPM #
## Package Management for Node.js on Linux ##

Exposes the nodejs package management system for Linux systems to the Azure DevTest Labs users.

Now users can install whatever software they wish via npm in a way that is natural to people familiar with Node.js.

Please see README.md for list of supported distributions and usage.

> Note: This does not install NPM as part of its execution. This is due to the vast ways that users will want to make use of to get the nodejs/npm version of their choice onto the Linux distribution of their choice. The prescribed manner that people will use this artifact is part of a chain such as: Bash artifact to setup the PPA for the desired version of node on the desired Linux distribution + Apt or Yum artifact to install nodejs/npm + this artifact to install npm packages.