### PR TITLE
Updated call to context to use new syntax

### DIFF
--- a/PowerShell/AzureRM.DevTestLab/AzureRM.DevTestLab.psm1
+++ b/PowerShell/AzureRM.DevTestLab/AzureRM.DevTestLab.psm1
@@ -1088,7 +1088,7 @@ function New-AzureRmDtlLabStorageContext
         Write-Verbose $("Successfully extracted the storage account key for lab '" + $Lab.Name +"'")
 
         # Create a new storage context using the lab's default storage account .
-        New-AzureStorageContext -StorageAccountName $labStorageAccount.ResourceName -StorageAccountKey $labStorageAccountKey.Key1 | Write-Output
+        New-AzureStorageContext -StorageAccountName $labStorageAccount.ResourceName -StorageAccountKey $labStorageAccountKey[0].Value | Write-Output
     }
 }
 


### PR DESCRIPTION
This code was written before the syntax change that PowerShell made in
version 1.4. Anyone with a newer version will get an error if you try to
use this script, so this change updates the code to work with the new
object output by Get-AzureRmStorageAccountKey. More info here:
https://msdn.microsoft.com/en-us/library/mt607145.aspx