### PR TITLE
stop disabling PSRemoting

### DIFF
--- a/Artifacts/windows-7zip/startChocolatey.ps1
+++ b/Artifacts/windows-7zip/startChocolatey.ps1
@@ -46,7 +46,6 @@ $command = $PSScriptRoot + "\ChocolateyPackageInstaller.ps1"
 # Run Chocolatey as the artifactInstaller user
 Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-#Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-atom/startChocolatey.ps1
+++ b/Artifacts/windows-atom/startChocolatey.ps1
@@ -29,4 +29,3 @@ Invoke-Command -Credential $credential -ComputerName $env:COMPUTERNAME -ScriptBl
 }
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force

--- a/Artifacts/windows-azurepowershell/StartChocolatey.ps1
+++ b/Artifacts/windows-azurepowershell/StartChocolatey.ps1
@@ -51,7 +51,6 @@ Enable-PSRemoting -Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 $exitCode = Invoke-Command -ScriptBlock $scriptBlock -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList @($ProductId, $PSScriptRoot)
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-chocolatey/startChocolatey.ps1
+++ b/Artifacts/windows-chocolatey/startChocolatey.ps1
@@ -50,7 +50,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-chrome/startChocolatey.ps1
+++ b/Artifacts/windows-chrome/startChocolatey.ps1
@@ -46,7 +46,6 @@ $command = $PSScriptRoot + "\ChocolateyPackageInstaller.ps1"
 # Run Chocolatey as the artifactInstaller user
 Enable-PSRemoting –force
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-clone-git-repo/StartChocolatey.ps1
+++ b/Artifacts/windows-clone-git-repo/StartChocolatey.ps1
@@ -59,7 +59,6 @@ $scriptBlock = [scriptblock]::Create($scriptContent)
 # Run Chocolatey as the artifactInstaller user
 Enable-PSRemoting -Force -SkipNetworkProfileCheck
 $exitCode = Invoke-Command -ScriptBlock $scriptBlock -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList @($GitRepoLocation, $GitLocalRepoLocation, $GitBranch, $PersonalAccessToken, $PSScriptRoot)
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-dotnet45/startChocolatey.ps1
+++ b/Artifacts/windows-dotnet45/startChocolatey.ps1
@@ -50,7 +50,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-fiddler/startChocolatey.ps1
+++ b/Artifacts/windows-fiddler/startChocolatey.ps1
@@ -50,7 +50,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-firefox/startChocolatey.ps1
+++ b/Artifacts/windows-firefox/startChocolatey.ps1
@@ -46,7 +46,6 @@ $command = $PSScriptRoot + "\ChocolateyPackageInstaller.ps1"
 # Run Chocolatey as the artifactInstaller user
 Enable-PSRemoting -Force -SkipNetworkProfileCheck
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-git/startChocolatey.ps1
+++ b/Artifacts/windows-git/startChocolatey.ps1
@@ -50,7 +50,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-intellij/startChocolatey.ps1
+++ b/Artifacts/windows-intellij/startChocolatey.ps1
@@ -50,7 +50,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-mongodb/startChocolatey.ps1
+++ b/Artifacts/windows-mongodb/startChocolatey.ps1
@@ -50,7 +50,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-node/startChocolatey.ps1
+++ b/Artifacts/windows-node/startChocolatey.ps1
@@ -50,7 +50,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-notepadplusplus/startChocolatey.ps1
+++ b/Artifacts/windows-notepadplusplus/startChocolatey.ps1
@@ -50,7 +50,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-putty/startChocolatey.ps1
+++ b/Artifacts/windows-putty/startChocolatey.ps1
@@ -48,7 +48,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-servicefabric/InstallServiceFabric.ps1
+++ b/Artifacts/windows-servicefabric/InstallServiceFabric.ps1
@@ -86,8 +86,6 @@ catch
 finally
 {
     $ErrorActionPreference = "Continue"
-    
-    Disable-PSRemoting -Force
 
     # Delete the artifactInstaller user
     $cn.Delete("User", $userName)

--- a/Artifacts/windows-slack/startChocolatey.ps1
+++ b/Artifacts/windows-slack/startChocolatey.ps1
@@ -23,4 +23,3 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force

--- a/Artifacts/windows-sublime-text/startChocolatey.ps1
+++ b/Artifacts/windows-sublime-text/startChocolatey.ps1
@@ -48,7 +48,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)

--- a/Artifacts/windows-sysinternals/startChocolatey.ps1
+++ b/Artifacts/windows-sysinternals/startChocolatey.ps1
@@ -48,7 +48,6 @@ Enable-PSRemoting –Force -SkipNetworkProfileCheck
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
 
 Invoke-Command -FilePath $command -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $packageList
-Disable-PSRemoting -Force
 
 # Delete the artifactInstaller user
 $cn.Delete("User", $userName)


### PR DESCRIPTION
Disabling PSRemoting has bad side effects on other scripts and VSTS tasks so removing the call from all of the artifacts.