### PR TITLE
Adding quickstart template for the VM expiration date feature.

### DIFF
--- a/ARMTemplates/101-dtl-create-vm-username-pwd-customimage-with-expiration/README.md
+++ b/ARMTemplates/101-dtl-create-vm-username-pwd-customimage-with-expiration/README.md
@@ -1,0 +1,13 @@
+# Create a new virtual machine in a DevTestLab instance with a specified expiration date.
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F101-dtl-create-vm-username-pwd-customimage-with-expiration%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+
+This deployment template is generally used with sysprepped VHDs.
+
+This template creates a new virtual machine in a DevTestLab instance.
+- A new user account is created using the username/password combination specified.
+- This user account is added to the local administrators group.
+- This VM will be deleted within 24 hrs of expiration date.

--- a/ARMTemplates/101-dtl-create-vm-username-pwd-customimage-with-expiration/azuredeploy.json
+++ b/ARMTemplates/101-dtl-create-vm-username-pwd-customimage-with-expiration/azuredeploy.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newVMName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the new vm to be created."
+      }
+    },
+    "existingLabName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of an existing lab where the new vm will be created."
+      }
+    },
+    "existingCustomImageId": {
+      "type": "string",
+      "metadata": {
+        "description": "The id of an existing custom image which will be used to create the new vm. The specified image must exist in the lab (identified via the 'existingLabName' parameter)."
+      }
+    },
+    "newVMSize": {
+      "type": "string",
+      "metadata": {
+        "description": "The size of the new vm to be created."
+      }
+    },
+    "userName": {
+      "type": "string",
+      "metadata": {
+        "description": "The username for the local account that will be created on the new vm."
+      }
+    },
+    "password": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password for the local account that will be created on the new vm."
+      }
+    },
+    "expirationDate": {
+      "type": "string",
+      "metadata": {
+        "description": "The expiration date for the VM."
+      }
+    }
+  },
+  "variables": {
+    "labSubnetName": "[concat(variables('labVirtualNetworkName'), 'Subnet')]",
+    "labVirtualNetworkId": "[resourceId('Microsoft.DevTestLab/labs/virtualnetworks', parameters('existingLabName'), variables('labVirtualNetworkName'))]",
+    "labVirtualNetworkName": "[concat('Dtl', parameters('existingLabName'))]",
+    "resourceName": "[concat(parameters('existingLabName'), '/', parameters('newVMName'))]",
+    "resourceType": "Microsoft.DevTestLab/labs/virtualMachines"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-05-15",
+      "type": "Microsoft.DevTestLab/labs/virtualMachines",
+      "name": "[variables('resourceName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "customImageId": "[parameters('existingCustomImageId')]",
+        "size": "[parameters('newVMSize')]",
+        "isAuthenticationWithSshKey": false,
+        "userName": "[parameters('userName')]",
+        "sshKey": "",
+        "password": "[parameters('password')]",
+        "labVirtualNetworkId": "[variables('labVirtualNetworkId')]",
+        "labSubnetName": "[variables('labSubnetName')]",
+		"expirationDate": "[parameters('expirationDate')]"
+      }
+    }
+  ],
+  "outputs": {
+    "vmId": {
+      "type": "string",
+      "value": "[resourceId(variables('resourceType'), parameters('existingLabName'), parameters('newVMName'))]"
+    }
+  }
+}

--- a/ARMTemplates/101-dtl-create-vm-username-pwd-customimage-with-expiration/azuredeploy.parameters.json
+++ b/ARMTemplates/101-dtl-create-vm-username-pwd-customimage-with-expiration/azuredeploy.parameters.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newVMName": {
+      "value": "MyVM1pwdcus"
+    },
+    "existingLabName": {
+      "value": "MyLab1"
+    },
+    "existingCustomImageId": {
+      "value": "/subscriptions/1234a3bc-ee4e-4c7a-9709-1868a28b1d4d/resourceGroups/myRG234/providers/Microsoft.DevTestLab/labs/MyLab1/customImages/MyCustomImage1"
+    },
+    "newVMSize": {
+      "value": "Standard_A4"
+    },
+    "userName": {
+      "value": "SomeAdmin"
+    },
+    "password": {
+      "value": "SomePassword!"
+    },
+    "expirationDate": {
+      "value": "2016-10-01T12:00:00+00:00"
+    }
+  }
+}

--- a/ARMTemplates/101-dtl-create-vm-username-pwd-customimage-with-expiration/metadata.json
+++ b/ARMTemplates/101-dtl-create-vm-username-pwd-customimage-with-expiration/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Create a new VM in Azure DevTest Labs with new user account and set expiration for the VM",
+  "description": "This template creates a new VM in a DevTest Lab / DTL instance using a custom image",
+  "summary": "This template creates a new VM in a DevTest Lab instance and creates a new user account on the VM. The VM will be deleted within 24 hrs after expiration date.",
+  "githubUsername": "mithunshanbhag",
+  "dateUpdated": "2016-07-15"
+}


### PR DESCRIPTION
Submitting PR on behalf of Jogi. 

Currently, we only have a template to create VM (with expiration date) from existing custom images. But we'll add support for gallery image in the next work item.