### PR TITLE
Adding PowerShell on Linux artifact for Azure Dev Test Lab Linux VMs

### DIFF
--- a/Artifacts/linux-powershell/Artifactfile.json
+++ b/Artifacts/linux-powershell/Artifactfile.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
+    "title": "PowerShell on Linux",
+    "description": "Installs PowerShell on Linux either on CentOS 7 or Ubuntu 14.04 or 16.04 LTS.",
+    "tags": [
+        "powershell",
+        "Linux"
+    ],
+    "iconUri": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/Artifacts/windows-run-powershell/powershell.png",
+    "targetOsType": "Linux",
+    "parameters": {
+        "packages": {
+            "type": "string",
+            "displayName": "packageUrl",
+            "allowEmpty": false,
+            "description": "The PowerShell on Linux package URL based on the distribution type. The supported list of distributions and URLs are available at https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md"
+        }
+    },
+    "runCommand": {
+        "commandToExecute": "[concat('bash linux-apt-package.sh ', parameters('update'))]"
+    }
+}

--- a/Artifacts/linux-powershell/Artifactfile.json
+++ b/Artifacts/linux-powershell/Artifactfile.json
@@ -17,6 +17,6 @@
         }
     },
     "runCommand": {
-        "commandToExecute": "[concat('bash linux-apt-package.sh ', parameters('update'))]"
+        "commandToExecute": "[concat('bash linux-powershell.sh ', parameters('update'))]"
     }
 }

--- a/Artifacts/linux-powershell/Artifactfile.json
+++ b/Artifacts/linux-powershell/Artifactfile.json
@@ -2,6 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
     "title": "PowerShell on Linux",
     "description": "Installs PowerShell on Linux either on CentOS 7 or Ubuntu 14.04 or 16.04 LTS.",
+    "publisher": "PowerShell Magazine",    
     "tags": [
         "powershell",
         "Linux"

--- a/Artifacts/linux-powershell/Artifactfile.json
+++ b/Artifacts/linux-powershell/Artifactfile.json
@@ -9,14 +9,14 @@
     "iconUri": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/Artifacts/windows-run-powershell/powershell.png",
     "targetOsType": "Linux",
     "parameters": {
-        "packages": {
+        "packageUrl": {
             "type": "string",
-            "displayName": "packageUrl",
+            "displayName": "Package URL",
             "allowEmpty": false,
             "description": "The PowerShell on Linux package URL based on the distribution type. The supported list of distributions and URLs are available at https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md"
         }
     },
     "runCommand": {
-        "commandToExecute": "[concat('bash linux-powershell.sh ', parameters('update'))]"
+        "commandToExecute": "[concat('bash linux-powershell.sh ', parameters('packageUrl'))]"
     }
 }

--- a/Artifacts/linux-powershell/linux-powershell.sh
+++ b/Artifacts/linux-powershell/linux-powershell.sh
@@ -1,0 +1,26 @@
+# Script to install PowerShell on Linux package on Azure DevTest lab Linux VMs.
+#
+# NOTE: Intended for use by the Azure DevTest Lab artifact system.
+#
+# Usage: 
+#
+# linux-apt-package.sh PACKAGE-URL
+#
+
+#!/bin/bash
+
+set -e
+cd /tmp
+URL=$1
+FILE_NAME="${URL##*/}"
+echo "Downloading $FILE_NAME"
+wget $URL
+
+if [ -f /usr/bin/yum ] ; then
+    echo "Using yum package manager"
+    yum install -y $FILE_NAME
+elif [ -f /usr/bin/apt ] ; then
+    echo "Using apt package manager"
+    apt-get -q -y install libunwind8 libicu55
+    dpkg -i $FILE_NAME
+fi


### PR DESCRIPTION
This artifact will add support for installing PowerShell on Linux on DTL Linux VMs.