### PR TITLE
PowerShell on Linux Artifact: Fixed dependency install issue on Ubuntu 14.04

### DIFF
--- a/Artifacts/linux-powershell/linux-powershell.sh
+++ b/Artifacts/linux-powershell/linux-powershell.sh
@@ -4,7 +4,7 @@
 #
 # Usage: 
 #
-# linux-apt-package.sh PACKAGE-URL
+# linux-powershell.sh PACKAGE-URL
 #
 
 #!/bin/bash
@@ -21,6 +21,11 @@ if [ -f /usr/bin/yum ] ; then
     yum install -y $FILE_NAME
 elif [ -f /usr/bin/apt ] ; then
     echo "Using apt package manager"
-    apt-get -q -y install libunwind8 libicu55
-    dpkg -i $FILE_NAME
+    if [ $(lsb_release -r -s) = "16.04" ]; then
+        apt-get -q -y install libunwind8 libicu55
+        dpkg -i $FILE_NAME
+    elif [ $(lsb_release -r -s) = "14.04" ]; then
+        apt-get -q -y install libunwind8 libicu52
+        dpkg -i $FILE_NAME
+    fi
 fi


### PR DESCRIPTION
The initial release was not differentiating between 14.04 and 16.04
which was causing a failure for libicu55 which does not exist for 14.04.
The present fix checks for the LTS release version and takes necessary
action.