### PR TITLE
To prevent an issue while creating the custom images from a VM using …

### DIFF
--- a/Samples/ProvisionDemoLab/azuredeploy.json
+++ b/Samples/ProvisionDemoLab/azuredeploy.json
@@ -345,7 +345,7 @@
       "name": "[variables('testTemplateResourceName')]",
       "type": "Microsoft.DevTestLab/labs/customimages",
       "dependsOn": [
-        "[resourceId('Microsoft.DevTestLab/labs/virtualMachines', parameters('newLabName'), parameters('pilotVMName'))]"
+        "[resourceId('Microsoft.DevTestLab/labs/customimages', parameters('newLabName'), parameters('devBoxTemplateName'))]"
       ],
       "properties": {
         "vm": {
@@ -362,7 +362,7 @@
       "name": "[variables('goldenImageTemplateResourceName')]",
       "type": "Microsoft.DevTestLab/labs/customimages",
       "dependsOn": [
-        "[resourceId('Microsoft.DevTestLab/labs/virtualMachines', parameters('newLabName'), parameters('pilotVMName'))]"
+        "[resourceId('Microsoft.DevTestLab/labs/customimages', parameters('newLabName'), parameters('testBoxTemplateName'))]"
       ],
       "properties": {
         "vm": {

--- a/Samples/ProvisionDemoLab/azuredeploy.parameters.json
+++ b/Samples/ProvisionDemoLab/azuredeploy.parameters.json
@@ -42,7 +42,7 @@
       "value": "Standard_DS1_v2"
     },
     "VMStorageType": {
-      "value": "Standard"
+      "value": "Premium"
     },
     "username": {
       "value": "demolab"


### PR DESCRIPTION
…premium storage, changed the custom image creation to sequential as they were competing against each other to copy the VM blob.