### PR TITLE
Improving error handling during clean-up to avoid false-positives

### DIFF
--- a/Artifacts/windows-7zip/startChocolatey.ps1
+++ b/Artifacts/windows-7zip/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-atom/startChocolatey.ps1
+++ b/Artifacts/windows-atom/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-chocolatey/startChocolatey.ps1
+++ b/Artifacts/windows-chocolatey/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-chrome/startChocolatey.ps1
+++ b/Artifacts/windows-chrome/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-dotnet45/startChocolatey.ps1
+++ b/Artifacts/windows-dotnet45/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-fiddler/startChocolatey.ps1
+++ b/Artifacts/windows-fiddler/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-firefox/startChocolatey.ps1
+++ b/Artifacts/windows-firefox/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-git/startChocolatey.ps1
+++ b/Artifacts/windows-git/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-intellij/startChocolatey.ps1
+++ b/Artifacts/windows-intellij/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-mongodb/startChocolatey.ps1
+++ b/Artifacts/windows-mongodb/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-node/startChocolatey.ps1
+++ b/Artifacts/windows-node/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-notepadplusplus/startChocolatey.ps1
+++ b/Artifacts/windows-notepadplusplus/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-putty/startChocolatey.ps1
+++ b/Artifacts/windows-putty/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-selenium/startChocolatey.ps1
+++ b/Artifacts/windows-selenium/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-slack/startChocolatey.ps1
+++ b/Artifacts/windows-slack/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-sublime-text/startChocolatey.ps1
+++ b/Artifacts/windows-sublime-text/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-sysinternals/startChocolatey.ps1
+++ b/Artifacts/windows-sysinternals/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 

--- a/Artifacts/windows-webdeploy/startChocolatey.ps1
+++ b/Artifacts/windows-webdeploy/startChocolatey.ps1
@@ -171,7 +171,14 @@ function Remove-LocalAdminUser
     {
         $computer = [ADSI]"WinNT://$env:ComputerName"
         $computer.Delete('User', $UserName)
-        gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        try
+        {
+            gwmi win32_userprofile | ? { $_.LocalPath -like "*$UserName*" -and -not $_.Loaded } | % { $_.Delete() | Out-Null }
+        }
+        catch
+        {
+            # Ignore any errors, specially with locked folders/files. It will get cleaned up at a later time, when another artifact is installed.
+        }
     }
 }
 


### PR DESCRIPTION
- Adding a try-catch block when attempting to clean up, so that locked files don't prevent the artifact from completing installation.