### PR TITLE
Fixing Slack artifact

### DIFF
--- a/Artifacts/windows-slack/Artifactfile.json
+++ b/Artifacts/windows-slack/Artifactfile.json
@@ -21,6 +21,6 @@
         }
     },
     "runCommand": {
-        "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./startChocolatey.ps1 -PackageList ', 'slackmsix64', ' -UserName ', parameters('installUsername'), ' -Password ', parameters('installPassword'), '\"')]"
+        "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./startChocolatey.ps1 -PackageList ', 'slack', ' -UserName ', parameters('installUsername'), ' -Password ', parameters('installPassword'), '\"')]"
     }
 }


### PR DESCRIPTION
- Changing windows-slack artifact definition to replace not found package slackmsix64 to slack in definition file.