### PR TITLE
Adding api-version to VSTS Agent download.

### DIFF
--- a/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
+++ b/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
@@ -42,7 +42,7 @@ trap
     New-Item -ItemType Directory -Force -Path $agentTempFolderName
 
     $serverUrl = "https://$vstsAccount.visualstudio.com"
-    $vstsAgentUrl = "$serverUrl/_apis/distributedtask/packages/agent"
+    $vstsAgentUrl = "$serverUrl/_apis/distributedtask/packages/agent?api-version=2.3"
     $vstsUser = "AzureDevTestLabs"
 
     $retryCount = 3


### PR DESCRIPTION
An older api-version must be used, as the schema has changed.