### PR TITLE
Fixed template parameters extraction regex pattern

### DIFF
--- a/VstsTasks/AzureDtlCreateVM/task-funcs.ps1
+++ b/VstsTasks/AzureDtlCreateVM/task-funcs.ps1
@@ -83,7 +83,7 @@ function ConvertTo-TemplateParameterObject
     #    -newVMName '$(Build.BuildNumber)' -userName '$(User.Name)' -password (ConvertTo-SecureString -String '$(User.Password)' -AsPlainText -Force)
     #
     # the regular expression can be used to match newName, userName, password, etc.
-    $pattern = '\-(?<k>\w+)\s+(?<v>[''"].*?[''"]|\$\(.*\)?|\(.*\)?)'
+    $pattern = '\-(?<k>\w+)\s+(?<v>[''"].*?[''"]|\$\(.*\)?|\(.*\)[^\s]?)'
 
     $templateParameterObject = @{}
 

--- a/VstsTasks/AzureDtlCreateVM/task.json
+++ b/VstsTasks/AzureDtlCreateVM/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 10
+        "Patch": 11
     },
     "demands": [
         "azureps"

--- a/VstsTasks/vss-extension.json
+++ b/VstsTasks/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "tasks",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "name": "Azure DevTest Labs Tasks",
     "publisher": "ms-azuredevtestlabs",
     "description": "Collection of build/release tasks to interact with Azure DevTest Labs.",


### PR DESCRIPTION
Corrected regex used to extract parameters and their values to ensure that cases where parenthesis are used for the value in the middle of the TemplateParameters string, will still allow subsequent parameter definitions to be recognized.

For example, given the following TemplateParameters,

    -Foo 'foo' -password (ConvertTo-SecureString -String '********' -AsPlainText -Force) -Bar 'bar'

without this fix, the parameter Bar would never be recognized.