### PR TITLE
Ensure parameter values are passed from VSTS tasks

### DIFF
--- a/Artifacts/windows-clone-git-repo/Artifactfile.json
+++ b/Artifacts/windows-clone-git-repo/Artifactfile.json
@@ -34,6 +34,6 @@
         }
     },
     "runCommand": {
-        "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass -File StartChocolatey.ps1', ' -GitRepoLocation ', parameters('GitRepoURI'), ' -GitLocalRepoLocation \"', parameters('Destination'), '\" -GitBranch ', parameters('Branch'), ' -PersonalAccessToken ', parameters('PersonalAccessToken'))]"
+        "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./StartChocolatey.ps1 -GitRepoLocation ''', parameters('GitRepoURI'), ''' -GitLocalRepoLocation ''', parameters('Destination'), ''' -GitBranch ''', parameters('Branch'), ''' -PersonalAccessToken ''', parameters('PersonalAccessToken'), '''\"')]"
     }
 }


### PR DESCRIPTION
Not all secrets were making it to the ARM template. Changing the method used to invoke the PS script to ensure values are correctly passed.