### PR TITLE
Add User to Lab Example

### DIFF
--- a/ARMTemplates/301-dtl-add-lab-user/azuredeploy.json
+++ b/ARMTemplates/301-dtl-add-lab-user/azuredeploy.json
@@ -1,0 +1,51 @@
+﻿{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "principalId": {
+      "type": "string",
+      "metadata": {
+        "description": "The objectId of the user, group, or service principal for the role."
+      }
+    },
+    "labName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the new lab instance to be created."
+      }
+    },
+    "roleAssignmentGuid": {
+      "type": "string",
+      "metadata": {
+        "description": "Guid to use as the name for the role assignment."
+      }
+    }
+  },
+  "variables": {
+    "devTestLabUserRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/76283e04-6283-4c54-8f91-bcf1374a3c64')]",
+    "fullDevTestLabUserRoleName": "[concat(parameters('labName'), '/Microsoft.Authorization/', parameters('roleAssignmentGuid'))]",
+    "roleScope": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DevTestLab/labs/', parameters('labName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-05-15",
+      "type": "Microsoft.DevTestLab/labs",
+      "name": "[parameters('labName')]",
+      "location": "[resourceGroup().location]"
+    },
+    {
+      "apiVersion": "2016-07-01",
+      "type": "Microsoft.DevTestLab/labs/providers/roleAssignments",
+      "name": "[variables('fullDevTestLabUserRoleName')]",
+      "properties": {
+        "roleDefinitionId": "[variables('devTestLabUserRoleId')]",
+        "principalId": "[parameters('principalId')]",
+        "scope": "[variables('roleScope')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DevTestLab/labs', parameters('labName'))]"
+      ]
+    }
+  ]
+}
+

--- a/ARMTemplates/301-dtl-add-lab-user/azuredeploy.parameters.json
+++ b/ARMTemplates/301-dtl-add-lab-user/azuredeploy.parameters.json
@@ -1,0 +1,15 @@
+﻿{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "principalId": {
+      "value": "11111111-1111-1111-1111-111111111111"
+    },
+    "labName": {
+      "value": "MyLab"
+    },
+    "roleAssignmentGuid": {
+      "value": "385d337e-9eaa-42c6-820f-e8413012ae38"
+    }
+  }
+}

--- a/ARMTemplates/301-dtl-add-lab-user/metadata.json
+++ b/ARMTemplates/301-dtl-add-lab-user/metadata.json
@@ -1,0 +1,8 @@
+﻿{
+  "itemDisplayName": "Add user or group as a 'DevTest Labs User' to a Azure DevTest Labs instance.",
+  "description": "This template creates a new role assignment which adds the specified user or group as a 'DevTest Lab User' to the specified DevTest Lab instance.",
+  "summary": "This template creates a new 'DevTest Labs User' role assignment to a lab.",
+  "githubUsername": "emaher",
+  "dateUpdated": "2016-11-21"
+}
+

--- a/ARMTemplates/301-dtl-add-lab-user/readme.md
+++ b/ARMTemplates/301-dtl-add-lab-user/readme.md
@@ -1,0 +1,15 @@
+# Add Lab User to a DevTestLab instance
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F301-dtl-add-lab-user%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+
+This template creates a new role assignment which adds the specified user or group as a DevTest Lab User to the specified DevTest Lab instance.
+
+Parameters for template:
+
+-  **principalId**.   Principal Id is the ObjectId of the AD user or group that you want to add as a user to the DevTest Lab instance.  This information can be obtained using the [Get-AzureRMADUser] (https://msdn.microsoft.com/en-us/library/mt619420.aspx), [Get-AzureRMAdGroup](https://msdn.microsoft.com/en-us/library/mt603729.aspx) or [Get-AzureRMADServicePrincipal](https://msdn.microsoft.com/en-us/library/mt603710.aspx) PowerShell cmdlets.
+- **labName**. Name of lab to which you want to add the user.  Must be in same resource group that the arm template is being deployed to.
+- **roleAssignmentGuid**.  Name of the role assignment.  This can be any valid GUID as explained by the [Role Assignments](https://docs.microsoft.com/en-us/rest/api/authorization/roleassignments) documentation.
+


### PR DESCRIPTION
Example showing how to add a user to a DevTest Lab instance by adding a new Azure role assignment.