### PR TITLE
Fix for validation error on driveLetter

### DIFF
--- a/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
+++ b/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
@@ -30,7 +30,7 @@ Param(
     [Parameter(Mandatory=$true)]
     [ValidatePattern("[c-zC-Z]")]
     [ValidateLength(1, 1)]
-    $driveLetter,
+    [String]$driveLetter,
     
     [Parameter(Mandatory=$true)]
     [AllowEmptyString()]


### PR DESCRIPTION
DriveLetter needs to be forced into a String, otherwise the script will Error: Cannot validate argument on parameter 'driveLetter'.