### PR TITLE
Moving poweroff logic out of artifact

### DIFF
--- a/Artifacts/linux-deprovision/Artifactfile.json
+++ b/Artifacts/linux-deprovision/Artifactfile.json
@@ -9,5 +9,11 @@
     "targetOsType": "Linux",
     "runCommand": {
         "commandToExecute": "['sh depro.sh']"
-    }
+    },
+    "postDeployActions": [
+        {
+            "action": "deallocate",
+            "delayStart": 120
+        }
+    ]
 }

--- a/Artifacts/linux-deprovision/depro.sh
+++ b/Artifacts/linux-deprovision/depro.sh
@@ -2,7 +2,7 @@
 
 main () {
     { # try
-        echo 'waagent -force -deprovision+user && poweroff' | at now + 1 minute > /dev/null 2>&1
+        echo 'waagent -force -deprovision+user' | at now + 1 minute > /dev/null 2>&1
         exit 0
     } || { # catch
         exit 1


### PR DESCRIPTION
Moving poweroff logic out of the artifact and leveraging DTL support for shutting down the VM after deprovisioning.