### PR TITLE
Adding deallocate postDeployAction

### DIFF
--- a/Artifacts/windows-sysprep/Artifactfile.json
+++ b/Artifacts/windows-sysprep/Artifactfile.json
@@ -10,5 +10,10 @@
     "parameters": {},
     "runCommand": {
         "commandToExecute": "['powershell.exe -executionpolicy bypass -File Sysprep.ps1']"
-    }
+    },
+    "postDeployActions": [
+        {
+            "action": "deallocate"
+        }
+    ]
 }


### PR DESCRIPTION
Adding deallocate postDeployAction to ensure that VM is correctly deallocated, not just stopped.