### PR TITLE
Fix issues with the checksum for google artifact

### DIFF
--- a/Artifacts/windows-chrome/Artifactfile.json
+++ b/Artifacts/windows-chrome/Artifactfile.json
@@ -10,6 +10,6 @@
   "iconUri": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/Artifacts/windows-chrome/Google_Chrome_icon.png",
   "targetOsType": "Windows",
   "runCommand": {
-    "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./startChocolatey.ps1 -PackageList ', 'googlechrome-allusers', '\"')]"
+    "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./startChocolatey.ps1 -PackageList ', 'googlechrome', '\"')]"
   }
 }

--- a/Artifacts/windows-chrome/ChocolateyPackageInstaller.ps1
+++ b/Artifacts/windows-chrome/ChocolateyPackageInstaller.ps1
@@ -253,7 +253,7 @@ try
     InstallChocolatey -chocolateyInstallLog $ChocolateyInstallLog
 
     # install the specified packages
-    InstallPackages -packagesList $RawPackagesList 
+    InstallPackages -packagesList $RawPackagesList
 }
 catch
 {

--- a/Artifacts/windows-chrome/ChocolateyPackageInstaller.ps1
+++ b/Artifacts/windows-chrome/ChocolateyPackageInstaller.ps1
@@ -223,7 +223,8 @@ function InstallPackages
         WriteLog "Installing package: $package ..."
 
         # Install git via chocolatey.
-        choco install $package --force --yes --acceptlicense --verbose --allow-empty-checksums | Out-Null  
+        #ignoring the checksum for chrome package since the msi is not versioned in this package and the installer comes from a well known location        
+        choco install $package --force --yes --acceptlicense --verbose --ignorechecksum | Out-Null  
         if (-not $?)
         {
             $errMsg = 'Installation failed. Please see the chocolatey logs in %ALLUSERSPROFILE%\chocolatey\logs folder for details.'
@@ -252,7 +253,7 @@ try
     InstallChocolatey -chocolateyInstallLog $ChocolateyInstallLog
 
     # install the specified packages
-    InstallPackages -packagesList $RawPackagesList
+    InstallPackages -packagesList $RawPackagesList 
 }
 catch
 {


### PR DESCRIPTION
ignoring the checksum in the googlechrome package from chocolatey.  The msi is downloaded from a google site and is unversioned so this artifact is going to break from time to time without this change.