### PR TITLE
Added an artifact for creating a locally signed development certificate

### DIFF
--- a/Artifacts/windows-development-certificate/Artifactfile.json
+++ b/Artifacts/windows-development-certificate/Artifactfile.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
+    "title":  "Self Signed Certificate",
+    "publisher": "Vince Adams",
+    "description": "Installs a self signed certificate for use with development",
+    "tags": [
+        "Windows",
+        "Certificate",
+        "Development"
+    ],
+    "parameters": {
+        "dnsName": {
+        "type": "string",
+        "displayName": "DNS Name",
+        "description": "DNS to bind the certificate to i.e. *.localdev.com"
+        }
+    },
+    "targetOsType": "Windows",
+    "runCommand": {
+        "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./InstallCertificate.ps1 -dnsName ', parameters('dnsName'), '\"')]"
+    }
+}

--- a/Artifacts/windows-development-certificate/InstallCertificate.ps1
+++ b/Artifacts/windows-development-certificate/InstallCertificate.ps1
@@ -1,0 +1,47 @@
+<#
+Creates a self signed certificate and imports it into you Persoanl and Root stores. 
+I used this when setting up a new development site on dev machine.
+#>
+Param(
+    [ValidateNotNullOrEmpty()]
+    [string]$dnsName
+)
+
+
+##################################################################################################
+
+#
+# Powershell Configurations
+#
+
+# Note: Because the $ErrorActionPreference is "Stop", this script will stop on first failure.  
+$ErrorActionPreference = "Stop"
+
+# Ensure that current process can run scripts. 
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force 
+
+If(-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
+{
+    #build up the deploy arguments
+    $arguments = "-file `"{0}`"" -f $script:MyInvocation.MyCommand.Path
+    
+    # Start the new process
+    Start-Process powershell.exe -Verb runas -ArgumentList $arguments
+    exit
+}
+else
+{
+    $pfx = new-SelfSignedCertificate -DnsName $dnsName -CertStoreLocation cert:\LocalMachine\My
+    $friendlyName = "SelfSigned-" + $dnsName
+    "Using freindly name " + $friendlyName | Write-Host
+    $pfx.FriendlyName = $friendlyName    
+    $store =  new-object System.Security.Cryptography.X509Certificates.X509Store(
+        [System.Security.Cryptography.X509Certificates.StoreName]::Root,
+        "localmachine"
+    )
+    $store.open("MaxAllowed") 
+    $store.add($pfx) 
+    $store.close()
+    Write-Host "Certificate added to the Personal and Root stores succesfully"
+}
+


### PR DESCRIPTION
This artifact will add a locally signed development certificate to the users trusted root and personal stores.  This can be used in conjuction with iis to test devlopment websites against a secure connection. 