### PR TITLE
Fixed chocolatey package name.

### DIFF
--- a/Artifacts/windows-dotnet45/Artifactfile.json
+++ b/Artifacts/windows-dotnet45/Artifactfile.json
@@ -10,6 +10,6 @@
     "iconUri": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/Artifacts/windows-dotnet45/dotnet.png",
     "targetOsType": "Windows",
     "runCommand": {
-        "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./startChocolatey.ps1 -PackageList ', 'dotnet45', '\"')]"
+        "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./startChocolatey.ps1 -PackageList ', 'dotnet4.5', '\"')]"
     }
 }


### PR DESCRIPTION
The package name defined on Artifactfile.json is actually wrong. It should be dotnet4.5 otherwise it will fail, since the package will not be found on source (https://chocolatey.org/api/v2/).