### PR TITLE
Adding sample artifact to show supported parameter types.

### DIFF
--- a/Artifacts/windows-test-paramtypes/artifact.ps1
+++ b/Artifacts/windows-test-paramtypes/artifact.ps1
@@ -1,0 +1,96 @@
+[CmdletBinding()]
+param(
+    [string] $StringParam,
+    [securestring] $SecureStringParam,
+    [int] $IntParam,
+    [switch] $BoolParam,
+    [string] $ArrayParam,
+    [string] $ObjectParam,
+    [int] $ExtraLogLines,
+    [switch] $ForceFail
+)
+
+###################################################################################################
+
+#
+# PowerShell configurations
+#
+
+# NOTE: Because the $ErrorActionPreference is "Stop", this script will stop on first failure.
+#       This is necessary to ensure we capture errors inside the try-catch-finally block.
+$ErrorActionPreference = "Stop"
+
+# Ensure we set the working directory to that of the script.
+pushd $PSScriptRoot
+
+###################################################################################################
+
+#
+# Functions used in this script.
+#
+
+function Handle-LastError
+{
+    [CmdletBinding()]
+    param(
+    )
+
+    $message = $error[0].Exception.Message
+    if ($message)
+    {
+        Write-Host -Object "ERROR: $message" -ForegroundColor Red
+    }
+    
+    # IMPORTANT NOTE: Throwing a terminating error (using $ErrorActionPreference = "Stop") still
+    # returns exit code zero from the PowerShell script when using -File. The workaround is to
+    # NOT use -File when calling this script and leverage the try-catch-finally block and return
+    # a non-zero exit code from the catch block.
+    exit -1
+}
+
+###################################################################################################
+
+#
+# Handle all errors in this script.
+#
+
+trap
+{
+    # NOTE: This trap will handle all errors. There should be no need to use a catch below in this
+    #       script, unless you want to ignore a specific error.
+    Handle-LastError
+}
+
+###################################################################################################
+
+#
+# Main execution block.
+#
+
+try
+{
+    Write-Output 'Processing parameters:'
+    Write-Output "  string: $StringParam"
+    Write-Output "  securestring: '********'"
+    Write-Output "  int: $IntParam"
+    Write-Output "  bool: $BoolParam"
+    Write-Output "  array: $(ConvertFrom-Json $ArrayParam)"
+    Write-Output "  object: $(ConvertFrom-Json $ObjectParam)"
+
+    if ($ExtraLogLines -gt 0)
+    {
+        Write-Output 'Dumping extra log lines:'
+        1..$ExtraLogLines | % {
+            Write-Output "  INFO: Sample log line #$_"
+        }
+    }
+
+    if ($ForceFail)
+    {
+        throw 'Forcing artifact to fail.'
+    }
+}
+finally
+{
+    popd
+}

--- a/Artifacts/windows-test-paramtypes/artifactfile.json
+++ b/Artifacts/windows-test-paramtypes/artifactfile.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
+  "title": "Test Parameter Types",
+  "publisher": "Microsoft",
+  "description": "Template to test supported artifact parameter types.",
+  "tags": [
+    "Windows",
+    "Template"
+  ],
+  "targetOsType": "Windows",
+  "parameters": {
+    "stringParam": {
+      "type": "string",
+      "displayName": "String Parameter",
+      "description": "Any text string is allowed, including spaces.",
+      "defaultValue": "Default string param value",
+      "allowEmpty": true
+    },
+    "securestringParam": {
+      "type": "securestring",
+      "displayName": "Secure String Parameter",
+      "description": "Any text string is allowed, including spaces, and will be presented in UI as masked characters.",
+      "allowEmpty": true
+    },
+    "intParam": {
+      "type": "int",
+      "displayName": "Integer Parameter",
+      "description": "Any integer value is allowed.",
+      "defaultValue": 0,
+      "allowEmpty": true
+    },
+    "boolParam": {
+      "type": "bool",
+      "displayName": "Boolean Parameter",
+      "description": "Only valid boolean values are allowed (i.e. true, false, 0, 1).",
+      "defaultValue": false,
+      "allowEmpty": true
+    },
+    "selectParam": {
+      "type": "string",
+      "displayName": "Select Parameter",
+      "description": "Only a selection from the list is allowed.",
+      "defaultValue": "",
+      "allowEmpty": false,
+      "allowedValues": [
+        "test1",
+        "test2"
+      ]
+    },
+    "arrayParam": {
+      "type": "array",
+      "displayName": "Array Parameter",
+      "description": "To specify multiple values, format them as a JSON array (e.g. [\"item1\", \"item2\"]).",
+      "defaultValue": ["item1", "item2"], 
+      "allowEmpty": true
+    },
+    "objectParam": {
+      "type": "object",
+      "displayName": "Object Parameter",
+      "description": "To specify multiple properties, format them as a JSON object (e.g. { prop1: \"value1\", prop2: \"value2\" }).",
+      "defaultValue": { "prop1": "value1", "prop2": "value2" }, 
+      "allowEmpty": true
+    },
+    "extraLogLines": {
+      "type": "int",
+      "displayName": "Extra Log Lines",
+      "description": "Number of additional lines to log as part of the Extension Message.",
+      "defaultValue": 0,
+      "allowEmpty": true
+    },
+    "forceFail": {
+      "type": "bool",
+      "displayName": "Force Fail",
+      "description": "For the artifact to fail by throwing an exception.",
+      "defaultValue": false,
+      "allowEmpty": true
+    }
+  },
+  "runCommand": {
+    "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./artifact.ps1 -StringParam ''', parameters('stringParam'), ''' -SecureStringParam (ConvertTo-SecureString ''', parameters('securestringParam'), ''' -AsPlainText -Force) -IntParam ', parameters('intParam'), ' -BoolParam:$', parameters('boolParam'), ' -ExtraLogLines ', parameters('extraLogLines'), ' -ForceFail:$', parameters('forceFail'), '\"')]"
+  }
+}


### PR DESCRIPTION
This is a sample to demonstrate the supported parameter types for artifacts. It also shows a proper structure for the accompanying PowerShell script to ensure errors are bubbled up correctly to the UI.