### PR TITLE
Updating Service Fabrick SDK artifact to handle minimal Visual Studio install.

### DIFF
--- a/Artifacts/windows-ServiceFabricSDK/InstallServiceFabricSDKAndTools.ps1
+++ b/Artifacts/windows-ServiceFabricSDK/InstallServiceFabricSDKAndTools.ps1
@@ -131,6 +131,6 @@ if ($VSVersion -ge 15){
    #Find VS Install Path(s) and add Service Fabric component.
    foreach ($VSInstallPathInfo in $vsInstallInfoArray){
         Write-Output "Enabling component for Service Fabric Tools for installation $($VSInstallPathInfo.InstallationPath)"
-        StartAndWaitForProcess $vsInstallExe "modify --installPath `"$($VSInstallPathInfo.InstallationPath)`" --add Microsoft.VisualStudio.Component.Azure.ServiceFabric.Tools --quiet --norestart" @(0)
+        StartAndWaitForProcess $vsInstallExe "modify --installPath `"$($VSInstallPathInfo.InstallationPath)`" --add Microsoft.VisualStudio.Component.Azure.ServiceFabric.Tools --add Microsoft.VisualStudio.Workload.Azure --quiet --norestart" @(0)
     }
 }


### PR DESCRIPTION
Updating artifact to verify Azure workload is installed for Visual Studio.  This workload is required for the Service Fabric component.