### PR TITLE
Allow agentName to use the computer's name by default

### DIFF
--- a/Artifacts/windows-vsts-build-agent/Artifactfile.json
+++ b/Artifacts/windows-vsts-build-agent/Artifactfile.json
@@ -25,7 +25,8 @@
     "agentName": {
       "type": "string",
       "displayName": "Agent Name",
-      "description": "The name to give to the agent, as seen by VSTS."
+      "description": "The name to give to the agent, as seen by VSTS. If empty, the computer name will be used.",
+      "allowEmpty": true
     },
     "poolName": {
       "type": "string",

--- a/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
+++ b/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
@@ -16,6 +16,12 @@ param(
 
 ###################################################################################################
 
+# if the agentName is empty, use %COMPUTERNAME% as the value
+if ([String]::IsNullOrWhiteSpace($agentName))
+{
+    $agentName = $env:COMPUTERNAME
+}
+
 #
 # PowerShell configurations
 #


### PR DESCRIPTION
At least in scenarios within my team, we want to be able to spin up a set of machines (say, 15 or even 50) from a single action (see image below). This isn't currently possible to successfully do this and apply the VSTS Build Agent artifact in order to provision each of the machines in a VSTS agent pool.

This pull request enables that scenario by allowing the agent name to be empty (minor `Artifactfile.json` changes) and then removes the automatic `param` validation and instead sets `$agentName` to `%COMPUTERNAME%` if the parameter wasn't supplied by the user.

![image](https://user-images.githubusercontent.com/2736712/28693650-a950d37e-72da-11e7-8e1f-77d2879f72e5.png)