### PR TITLE
Changes for AutoStart support; changes for storage type selection

### DIFF
--- a/Scripts/University Repo/ScenarioScripts/Add-AzureDtlVM.ps1
+++ b/Scripts/University Repo/ScenarioScripts/Add-AzureDtlVM.ps1
@@ -68,6 +68,14 @@
 
 
 
+.PARAMETER StorageType
+
+	Optional. Type of storage
+
+	Default "Standard".
+
+
+
 .PARAMETER VMNameBase
 
     Optional. Prefix for new VMs.
@@ -233,6 +241,12 @@ param
     [Parameter(Mandatory = $false, HelpMessage = "Size of VM image")]
 
     [string] $Size = "Standard_A2_v2",    
+
+
+
+	[Parameter(Mandatory = $false, HelpMessage = "Type of storage")]
+
+	[string] $StorageType = "Standard",
 
 
 
@@ -556,6 +570,7 @@ try {
 
             EnableStartupTime  = If ($EnableStartupTime) {"true"} Else {"false"}
 
+			StorageType        = $StorageType
         }
 
 

--- a/Scripts/University Repo/ScenarioScripts/Add-AzureDtlVM.ps1
+++ b/Scripts/University Repo/ScenarioScripts/Add-AzureDtlVM.ps1
@@ -110,7 +110,7 @@
 
 .PARAMETER profilePath
 
-    Optional. Path to file with Azure Profile.
+    Optional. Path to file with Azure Profile. How to generate this file is explained at the end of the Readme for the repo (https://github.com/lucabol/University).
 
     Default "$env:APPDATA\AzProfile.txt".
 
@@ -137,6 +137,18 @@
     Optional. Shutdown time for the VMs in the lab. In form of 'HH:mm' in TimeZoneID timezone.
 
     Default $ExpirationTime.
+
+    
+
+.PARAMETER StartupTime
+
+    Optional. Starting time for the VMS in the lab. In form of 'HH:mm' in TimeZoneID timezone. You need to set EnableStartupTime to $true as well.
+
+
+
+.PARAMETER EnableStartupTime
+
+    Optional. Set to $true to enable starting up of machine at startup time.
 
 
 
@@ -269,6 +281,18 @@ param
     [Parameter(Mandatory = $false, HelpMessage = "What time to expire the VMs at. Defaults to 3am. In form of 'HH:mm' in TimeZoneID timezone")]
 
     [string] $ExpirationTime = "03:00",
+
+
+
+    [Parameter(Mandatory = $false, HelpMessage = "What time to start the VMs at. In form of 'HH:mm' in TimeZoneID timezone")]
+
+    [string] $StartupTime = "02:30",
+
+
+
+    [Parameter(Mandatory = $false, HelpMessage = "Set to true to enable starting up of machine at startup time.")]
+
+    [boolean] $EnableStartupTime,
 
 
 
@@ -426,6 +450,12 @@ try {
 
 
 
+    $StartupTimeHours = ([DateTime]$StartupTime).ToString("HHmm")
+    
+    LogOutput "Startup Time hours: $StartupTimeHours"
+
+
+
     LogOutput "Start deployment of Shutdown time ..."
 
     $shutParams = @{
@@ -433,6 +463,8 @@ try {
         newLabName   = $LabName
 
         shutDownTime = $ShutDownTimeHours
+
+        startupTime  = $StartupTimeHours
 
         timeZoneId   = $TimeZoneId
 
@@ -521,6 +553,8 @@ try {
             TimeZoneId         = $TimeZoneId
 
             VirtualNetworkName = $VNetName
+
+            EnableStartupTime  = If ($EnableStartupTime) {"true"} Else {"false"}
 
         }
 

--- a/Scripts/University Repo/ScenarioScripts/Add-AzureDtlVMAutoVar.ps1
+++ b/Scripts/University Repo/ScenarioScripts/Add-AzureDtlVMAutoVar.ps1
@@ -187,6 +187,8 @@ try {
 
         $Size = Get-AutomationVariable -Name 'Size'
 
+		$StorageType = Get-AutomationVariable -Name 'StorageType'
+
         $TemplatePath = Get-AutomationVariable -Name 'TemplatePath'
 
     }
@@ -201,7 +203,7 @@ try {
 
     . .\Add-AzureDtlVM.ps1 -LabName $LabName -VMCount $VMCount -ImageName $ImageName -ShutDownTime $ShutDownTime -TotalLabSize $TotalLabSize `
 
-        -ShutdownPath $ShutdownPath -TemplatePath $TemplatePath -VNetName $VNetName -SubnetName $SubnetName -Size $Size -ExpirationTime $ExpirationTime -DaysToExpiry $DaysToExpiry `
+        -ShutdownPath $ShutdownPath -TemplatePath $TemplatePath -VNetName $VNetName -SubnetName $SubnetName -Size $Size -StorageType $StorageType -ExpirationTime $ExpirationTime -DaysToExpiry $DaysToExpiry `
 
         -StartupTime $StartupTime -EnableStartupTime $EnableStartupTime
 

--- a/Scripts/University Repo/ScenarioScripts/Add-AzureDtlVMAutoVar.ps1
+++ b/Scripts/University Repo/ScenarioScripts/Add-AzureDtlVMAutoVar.ps1
@@ -64,6 +64,18 @@
 
 
 
+.PARAMETER StartupTime
+
+    Optional. Starting time for the VMS in the lab. In form of 'HH:mm' in TimeZoneID timezone. You need to set EnableStartupTime to $true as well.
+
+
+
+.PARAMETER EnableStartupTime
+
+    Optional. Set to $true to enable starting up of machine at startup time.
+
+
+
 .EXAMPLE
 
     Add-AzureDtlVM -LabName University -VMCount 50 -ImageName "UnivImage" -TotalLabSize 200
@@ -126,8 +138,19 @@ param
 
     [Parameter(Mandatory = $false, HelpMessage = "Shutdown time for the VMs in the lab. In form of 'HH:mm' in TimeZoneID timezone")]
 
-    [string] $ShutDownTime = $ExpirationTime
+    [string] $ShutDownTime = $ExpirationTime,
 
+
+
+    [Parameter(Mandatory = $false, HelpMessage = "What time to start the VMs at. In form of 'HH:mm' in TimeZoneID timezone")]
+
+    [string] $StartupTime = "02:30",
+
+
+
+    [Parameter(Mandatory = $false, HelpMessage = "Set to true to enable starting up of machine at startup time.")]
+
+    [boolean] $EnableStartupTime
 )
 
 
@@ -178,7 +201,9 @@ try {
 
     . .\Add-AzureDtlVM.ps1 -LabName $LabName -VMCount $VMCount -ImageName $ImageName -ShutDownTime $ShutDownTime -TotalLabSize $TotalLabSize `
 
-        -ShutdownPath $ShutdownPath -TemplatePath $TemplatePath -VNetName $VNetName -SubnetName $SubnetName -Size $Size -ExpirationTime $ExpirationTime -DaysToExpiry $DaysToExpiry
+        -ShutdownPath $ShutdownPath -TemplatePath $TemplatePath -VNetName $VNetName -SubnetName $SubnetName -Size $Size -ExpirationTime $ExpirationTime -DaysToExpiry $DaysToExpiry `
+
+        -StartupTime $StartupTime -EnableStartupTime $EnableStartupTime
 
 } finally {
 

--- a/Scripts/University Repo/ScenarioScripts/Add-GroupPermissionsDevTestLab.ps1
+++ b/Scripts/University Repo/ScenarioScripts/Add-GroupPermissionsDevTestLab.ps1
@@ -34,7 +34,7 @@
 
 .PARAMETER profilePath
 
-    Optional. Path to file with Azure Profile.
+    Optional. Path to file with Azure Profile. How to generate this file is explained at the end of the Readme for the repo (https://github.com/lucabol/University).
 
     Default "$env:APPDATA\AzProfile.txt".
 

--- a/Scripts/University Repo/ScenarioScripts/Common.ps1
+++ b/Scripts/University Repo/ScenarioScripts/Common.ps1
@@ -1032,6 +1032,9 @@ function Create-VirtualMachines {
 
         $parameters = $json | ConvertTo-Hashtable
 
+        $str = $parameters | Out-String
+
+        LogOutput $str
 
 
         Invoke-AzureRmResourceAction -ResourceId "$LabId" -Action CreateEnvironment -Parameters $parameters -Force  | Out-Null

--- a/Scripts/University Repo/ScenarioScripts/DeallocateStoppedVM.ps1
+++ b/Scripts/University Repo/ScenarioScripts/DeallocateStoppedVM.ps1
@@ -22,7 +22,7 @@
 
 .PARAMETER profilePath
 
-    Optional. Path to file with Azure Profile.
+    Optional. Path to file with Azure Profile. How to generate this file is explained at the end of the Readme for the repo (https://github.com/lucabol/University).
 
     Default is "$env:APPDATA\AzProfile.txt"
 

--- a/Scripts/University Repo/ScenarioScripts/Remove-AzureDtlLabVMs.ps1
+++ b/Scripts/University Repo/ScenarioScripts/Remove-AzureDtlLabVMs.ps1
@@ -22,7 +22,7 @@
 
 .PARAMETER profilePath
 
-    Optional. Path to file with Azure Profile.
+    Optional. Path to file with Azure Profile. How to generate this file is explained at the end of the Readme for the repo (https://github.com/lucabol/University).
 
     Default "$env:APPDATA\AzProfile.txt".
 

--- a/Scripts/University Repo/ScenarioScripts/Remove-AzureDtlVM.ps1
+++ b/Scripts/University Repo/ScenarioScripts/Remove-AzureDtlVM.ps1
@@ -22,7 +22,7 @@
 
 .PARAMETER profilePath
 
-    Optional. Path to file with Azure Profile.
+    Optional. Path to file with Azure Profile. How to generate this file is explained at the end of the Readme for the repo (https://github.com/lucabol/University).
 
     Default is "$env:APPDATA\AzProfile.txt"
 

--- a/Scripts/University Repo/ScenarioScripts/Remove-GroupPermissionsDevTestLab.ps1
+++ b/Scripts/University Repo/ScenarioScripts/Remove-GroupPermissionsDevTestLab.ps1
@@ -34,7 +34,7 @@
 
 .PARAMETER profilePath
 
-    Optional. Path to file with Azure Profile.
+    Optional. Path to file with Azure Profile. How to generate this file is explained at the end of the Readme for the repo (https://github.com/lucabol/University).
 
     Default "$env:APPDATA\AzProfile.txt".
 

--- a/Scripts/University Repo/ScenarioScripts/Test-AzureDtlVMs.ps1
+++ b/Scripts/University Repo/ScenarioScripts/Test-AzureDtlVMs.ps1
@@ -26,7 +26,7 @@
 
 .PARAMETER profilePath
 
-    Optional. Path to file with Azure Profile.
+    Optional. Path to file with Azure Profile. How to generate this file is explained at the end of the Readme for the repo (https://github.com/lucabol/University).
 
     Default "$env:APPDATA\AzProfile.txt".
 

--- a/Scripts/University Repo/ScenarioScripts/dtl_multivm_customimage.json
+++ b/Scripts/University Repo/ScenarioScripts/dtl_multivm_customimage.json
@@ -52,6 +52,14 @@
 
         }
 
+	},
+
+    "tags": 
+
+    {
+
+        "AutoStartOn": "__EnableStartupTime__"
+
     }
 
 }

--- a/Scripts/University Repo/ScenarioScripts/dtl_multivm_customimage.json
+++ b/Scripts/University Repo/ScenarioScripts/dtl_multivm_customimage.json
@@ -20,7 +20,7 @@
 
         "disallowPublicIpAddress": true,
 
-        "storageType": "Standard",
+        "storageType": "__StorageType__",
 
         "allowClaim": true,
 

--- a/Scripts/University Repo/ScenarioScripts/dtl_shutdown.json
+++ b/Scripts/University Repo/ScenarioScripts/dtl_shutdown.json
@@ -22,6 +22,14 @@
 
     },
 
+	"startupTime": {
+
+      "type": "string",
+
+      "defaultValue": "03:00"
+
+    },
+
     "timeZoneId": {
 
       "type": "string",
@@ -93,6 +101,61 @@
             "dailyRecurrence": {
 
               "time": "[replace(parameters('shutDownTime'),':','')]"
+
+            }
+
+          }
+
+        },
+
+        {
+          "apiVersion": "2017-04-26-preview",
+
+          "name": "[concat(parameters('newLabName'), '/', 'LabVmAutoStart')]",
+
+          "location": "[resourceGroup().location]",
+
+          "type": "microsoft.devtestlab/labs/schedules",
+
+          "dependsOn": [
+
+            "[variables('labId')]"
+
+          ],
+
+          "properties": {
+
+            "status": "Enabled",
+
+            "timeZoneId": "[parameters('timeZoneId')]",
+
+            "weeklyRecurrence": {
+
+              "time": "[replace(parameters('startupTime'),':','')]",
+
+              "weekdays": [
+
+                "Monday",
+
+                "Tuesday",
+
+                "Wednesday",
+
+                "Thursday",
+
+                "Friday"
+
+              ]
+
+            },
+
+            "taskType": "LabVmsStartupTask",
+
+            "notificationSettings": {
+
+              "status": "Disabled",
+
+              "timeInMinutes": 15
 
             }
 


### PR DESCRIPTION
These changes allow you to set the AutoStart setting for the VMs.
Files involved:
- Add-AzureDtlVM.ps1 (added parameters)
- Add-AzureDtlVMAutoVar.ps1 (added parameters)
- Common.ps1 (added a log)
- dtl_multivm_customimage.json (added tag for autostart)
- dtl_shutdown.json (added properties for autostart)

Changes in other files are comments


----------------------------------------
Pull request update:

the latest commit added support for different storage type selection
Files involved:
- Add-AzureDtlVM.ps1 (added parameter for storage type)
- Add-AzureDtlVMAutoVar.ps1 (added parameters for storage type using Azure Automation variable)
- dtl_multivm_customimage.json (storage type parameterized)
