### PR TITLE
ImageFactory updates - improve SnapImages reliability, fix cleanup scripts and update logging

### DIFF
--- a/Scripts/ImageFactory/Configuration/GoldenImages/Win2012R2/SQLServer 2016 Express.json
+++ b/Scripts/ImageFactory/Configuration/GoldenImages/Win2012R2/SQLServer 2016 Express.json
@@ -22,20 +22,20 @@
     "labSubnetName": "[concat(variables('labVirtualNetworkName'), 'Subnet')]",
     "labVirtualNetworkId": "[resourceId('Microsoft.DevTestLab/labs/virtualnetworks', parameters('labName'), variables('labVirtualNetworkName'))]",
     "labVirtualNetworkName": "[concat('Dtl', parameters('labName'))]",
-    "vmId": "[resourceId ('Microsoft.DevTestLab/labs/virtualMachines', parameters('labName'), parameters('newVMName'))]",
+    "vmId": "[resourceId ('Microsoft.DevTestLab/labs/virtualmachines', parameters('labName'), parameters('newVMName'))]",
     "vmName": "[concat(parameters('labName'), '/', parameters('newVMName'))]"
   },
   "resources": [
     {
       "apiVersion": "2017-04-26-preview",
-      "type": "Microsoft.DevTestLab/labs/virtualMachines",
+      "type": "Microsoft.DevTestLab/labs/virtualmachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
       "properties": {
         "labVirtualNetworkId": "[variables('labVirtualNetworkId')]",
-        "notes": "SQL Server 2016 RTM Express on Windows Server 2012 R2",
+        "notes": "Free License: SQL Server 2016 SP1 Express on Windows Server 2016",
         "galleryImageReference": {
-          "offer": "SQL2016-WS2012R2",
+          "offer": "SQL2016SP1-WS2016",
           "publisher": "MicrosoftSQLServer",
           "sku": "Express",
           "osType": "Windows",
@@ -47,7 +47,8 @@
         "isAuthenticationWithSshKey": false,
         "labSubnetName": "[variables('labSubnetName')]",
         "disallowPublicIpAddress": false,
-        "storageType": "Standard"
+        "storageType": "Standard",
+        "allowClaim": false
       }
     }
   ],

--- a/Scripts/ImageFactory/Configuration/GoldenImages/Win2012R2/VS2015 Enterprise with Azure SDK.json
+++ b/Scripts/ImageFactory/Configuration/GoldenImages/Win2012R2/VS2015 Enterprise with Azure SDK.json
@@ -22,22 +22,22 @@
     "labSubnetName": "[concat(variables('labVirtualNetworkName'), 'Subnet')]",
     "labVirtualNetworkId": "[resourceId('Microsoft.DevTestLab/labs/virtualnetworks', parameters('labName'), variables('labVirtualNetworkName'))]",
     "labVirtualNetworkName": "[concat('Dtl', parameters('labName'))]",
-    "vmId": "[resourceId ('Microsoft.DevTestLab/labs/virtualMachines', parameters('labName'), parameters('newVMName'))]",
+    "vmId": "[resourceId ('Microsoft.DevTestLab/labs/virtualmachines', parameters('labName'), parameters('newVMName'))]",
     "vmName": "[concat(parameters('labName'), '/', parameters('newVMName'))]"
   },
   "resources": [
     {
       "apiVersion": "2017-04-26-preview",
-      "type": "Microsoft.DevTestLab/labs/virtualMachines",
+      "type": "Microsoft.DevTestLab/labs/virtualmachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
       "properties": {
         "labVirtualNetworkId": "[variables('labVirtualNetworkId')]",
-        "notes": "Visual Studio Enterprise 2015 Update 3 with Azure SDK 2.9.1 on Windows Server 2012 R2",
+        "notes": "Visual Studio Enterprise 2015 Update 3 with Azure SDK 2.9 on Windows Server 2012 R2",
         "galleryImageReference": {
           "offer": "VisualStudio",
           "publisher": "MicrosoftVisualStudio",
-          "sku": "VS-2015-Ent-VSU3-AzureSDK-291-WS2012R2",
+          "sku": "VS-2015-Ent-VSU3-AzureSDK-29-WS2012R2",
           "osType": "Windows",
           "version": "latest"
         },
@@ -47,7 +47,8 @@
         "isAuthenticationWithSshKey": false,
         "labSubnetName": "[variables('labSubnetName')]",
         "disallowPublicIpAddress": false,
-        "storageType": "Standard"
+        "storageType": "Standard",
+        "allowClaim": false
       }
     }
   ],

--- a/Scripts/ImageFactory/Configuration/GoldenImages/Win2016/Datacenter.json
+++ b/Scripts/ImageFactory/Configuration/GoldenImages/Win2016/Datacenter.json
@@ -22,13 +22,13 @@
     "labSubnetName": "[concat(variables('labVirtualNetworkName'), 'Subnet')]",
     "labVirtualNetworkId": "[resourceId('Microsoft.DevTestLab/labs/virtualnetworks', parameters('labName'), variables('labVirtualNetworkName'))]",
     "labVirtualNetworkName": "[concat('Dtl', parameters('labName'))]",
-    "vmId": "[resourceId ('Microsoft.DevTestLab/labs/virtualMachines', parameters('labName'), parameters('newVMName'))]",
+    "vmId": "[resourceId ('Microsoft.DevTestLab/labs/virtualmachines', parameters('labName'), parameters('newVMName'))]",
     "vmName": "[concat(parameters('labName'), '/', parameters('newVMName'))]"
   },
   "resources": [
     {
       "apiVersion": "2017-04-26-preview",
-      "type": "Microsoft.DevTestLab/labs/virtualMachines",
+      "type": "Microsoft.DevTestLab/labs/virtualmachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -47,7 +47,8 @@
         "isAuthenticationWithSshKey": false,
         "labSubnetName": "[variables('labSubnetName')]",
         "disallowPublicIpAddress": false,
-        "storageType": "Standard"
+        "storageType": "Standard",
+        "allowClaim": false
       }
     }
   ],

--- a/Scripts/ImageFactory/Scripts/CleanDeploymentHistory.ps1
+++ b/Scripts/ImageFactory/Scripts/CleanDeploymentHistory.ps1
@@ -1,0 +1,64 @@
+﻿param
+(
+    [Parameter(Mandatory=$true, HelpMessage="The name of the DevTest Lab to clean up")]
+    [string] $DevTestLabName
+)
+
+function CleanRGDeployments($resourceGroup, $modulePath)
+{
+    $maxConcurrentJobs = 25
+    $jobs = @()
+
+    # Script block for deleting images
+    $myCodeBlock = {
+        Param($modulePath, $subscriptionId, $rgName, $deployName)
+        Import-Module $modulePath
+        LoadProfile
+        Select-AzureRmSubscription -SubscriptionId $subscriptionId | Out-Null
+
+        Write-Output "  Deleting $deployName"
+        Remove-AzureRmResourceGroupDeployment -Name $deployName -ResourceGroupName $rgName | Out-Null
+    }
+
+    $subscriptionId = (Get-AzureRmContext).Subscription.Id
+    $dateCutoff = (Get-Date).AddDays(-15)
+
+    $allDeploys = Get-AzureRmResourceGroupDeployment -Id $resourceGroup.id
+
+    $deleteDeploys = $allDeploys | Where-Object {$_.ProvisioningState -eq 'Succeeded' -or $_.Timestamp -lt $dateCutoff}
+
+    Write-Output ("Deleting " + $deleteDeploys.Count + " of " + $allDeploys.Count + " deployments from " + $resourceGroup.Name)
+    $copyCount = $deleteDeploys.Count
+    $jobIndex = 0
+
+    foreach ($deploymentToDelete in $deleteDeploys){
+        #don't start more than $maxConcurrentJobs jobs at one time
+        while ((Get-Job -State 'Running').Count -ge $maxConcurrentJobs){
+            Write-Output "Throttling background tasks after starting $jobIndex of $copyCount tasks"
+            Start-Sleep -Seconds 10
+        }
+
+        $jobIndex++
+        $jobs += Start-Job -ScriptBlock $myCodeBlock -ArgumentList $modulePath, $subscriptionId, $deploymentToDelete.ResourceGroupName, $deploymentToDelete.DeploymentName
+    }
+
+    if($jobs.Count -ne 0)
+    {
+        Write-Output "Waiting for deployment deletion jobs to complete"
+        foreach ($job in $jobs){
+            Receive-Job $job -Wait | Write-Output
+        }
+        Remove-Job -Job $jobs
+    }
+}
+
+$modulePath = Join-Path (Split-Path ($Script:MyInvocation.MyCommand.Path)) "DistributionHelpers.psm1"
+Import-Module $modulePath
+SaveProfile
+
+$resourceGroups = Find-AzureRmResourceGroup | Where-Object {$_.Name.StartsWith($DevTestLabName, 'CurrentCultureIgnoreCase')}
+foreach($resGroup in $resourceGroups)
+{
+    # We have deployed a lot of artifacts. Remove those deployments so we dont hit the 800 deployment limit for our lab RGs
+    CleanRGDeployments $resGroup $modulePath
+}

--- a/Scripts/ImageFactory/Scripts/CleanUpFactory.ps1
+++ b/Scripts/ImageFactory/Scripts/CleanUpFactory.ps1
@@ -53,15 +53,6 @@ foreach ($currentVm in $allVms){
     }
 }
 
-# Find any custom images that failed to provision and delete those
-$ResourceGroupName = (Find-AzureRmResource -ResourceType 'Microsoft.DevTestLab/labs' | Where-Object { $_.Name -eq $DevTestLabName}).ResourceGroupName
-$bustedLabCustomImages = Get-AzureRmResource -ResourceName $DevTestLabName -ResourceGroupName $ResourceGroupName -ResourceType 'Microsoft.DevTestLab/labs/customImages' -ApiVersion '2016-05-15' | Where-Object {($_.Properties.ProvisioningState -ne "Succeeded") -and ($_.Properties.ProvisioningState -ne "Creating")}
-
-# Delete the custom images we found in the search above
-foreach ($imageToDelete in $bustedLabCustomImages) {
-    $jobs += Start-Job -Name $imageToDelete.ResourceName -ScriptBlock $deleteImageBlock -ArgumentList $modulePath, $imageToDelete.ResourceName, $imageToDelete.ResourceGroupName
-}
-
 if($jobs.Count -ne 0)
 {
     Write-Output "Waiting for VM Delete jobs to complete"

--- a/Scripts/ImageFactory/Scripts/DistributionHelpers.psm1
+++ b/Scripts/ImageFactory/Scripts/DistributionHelpers.psm1
@@ -33,23 +33,6 @@ function ShouldCopyImageToLab ($lab, $imagePathValue)
     $retval
 }
 
-function logMessageForUnusedImagePaths($labs, $configLocation)
-{
-    #iterate through each of the ImagePath entries in the lab and make sure that it points to at least one existing json file
-    $goldenImagesFolder = Join-Path $configLocation "GoldenImages"
-    $goldenImageFiles = Get-ChildItem $goldenImagesFolder -Recurse -Filter "*.json" | Select-Object FullName
-    foreach ($lab in $labs){
-        foreach ($labImagePath in $lab.ImagePaths){
-            $filePath = Join-Path $goldenImagesFolder $labImagePath
-            $matchingImages = $goldenImageFiles | Where-Object {$_.FullName.StartsWith($filePath,"CurrentCultureIgnoreCase")}
-            if($matchingImages.Count -eq 0){
-                $labName = $lab.LabName
-                Write-Error "The Lab named $labName contains an ImagePath entry $labImagePath which does not point to any existing files in the GoldenImages folder."
-            }
-        }
-    }
-}
-
 function ConvertTo-Object {
 
 	begin { $object = New-Object Object }
@@ -176,6 +159,7 @@ function GetImageInfosForLab ($DevTestLabName)
     foreach($file in $downloadedFileNames)
     {
         $imageObj = (gc $file.FullName -Raw) | ConvertFrom-Json
+        $imageObj.timestamp = [DateTime]::Parse($imageObj.timestamp)
         $sourceImageInfos += $imageObj
     }
 

--- a/Scripts/ImageFactory/Scripts/OutputImageList.ps1
+++ b/Scripts/ImageFactory/Scripts/OutputImageList.ps1
@@ -1,0 +1,20 @@
+﻿param
+(
+    [Parameter(Mandatory=$true, HelpMessage="The name of the DevTest Lab to clean up")]
+    [string] $DevTestLabName
+)
+
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path (Split-Path ($Script:MyInvocation.MyCommand.Path)) "DistributionHelpers.psm1"
+Import-Module $modulePath
+
+$sourceLab = Find-AzureRmResource -ResourceType 'Microsoft.DevTestLab/labs' | Where-Object { $_.Name -eq $DevTestLabName}
+
+if(!$sourceLab)
+{
+    Write-Error "Unable to find a lab named $DevTestLabName in $((Get-AzureRmContext).Subscription.Name)"
+}
+
+$labStorageInfo = GetLabStorageInfo $sourceLab
+GetImageInfosForLab $DevTestLabName | Sort-Object -Property osType, imagePath | Select-Object -Property imageName, imagePath, osType, timestamp

--- a/Scripts/ImageFactory/Scripts/RunImageFactory.ps1
+++ b/Scripts/ImageFactory/Scripts/RunImageFactory.ps1
@@ -1,0 +1,36 @@
+# Define some variables up fromt
+$subscriptionId = "<Subscription Id>"
+$devTestLabName = "<Name of the DevTest Lab>"
+$configurationFilesLocation = "<Local Directory that contains the configuration files>"
+$virtualmachineUsername = "adminuser"
+$virtualmachinePassword = "<a strong password>"
+
+Add-AzureRmAccount
+Select-AzureRmSubscription -SubscriptionId $subscriptionId
+
+# Scrape source code control for json files + create all VMs discovered
+.\MakeGoldenImageVMs.ps1    -ConfigurationLocation $configurationFilesLocation `
+                            -DevTestLabName $devTestLabName `
+                            -machineUserName $virtualmachineUsername `
+                            -machinePassword (ConvertTo-SecureString -String "$virtualmachinePassword" `
+                            -AsPlainText -Force) `
+                            -StandardTimeoutMinutes 60 `
+                            -vmSize "Standard_A2"
+
+# For all running VMs, save as images
+.\SnapImagesFromVMs.ps1 -DevTestLabName $devTestLabName
+
+# For all images, distribute to all labs who have 'signed up' for those images
+.\DistributeImages.ps1 -ConfigurationLocation $configurationFilesLocation `
+                       -SubscriptionId $subscriptionId `
+                       -DevTestLabName $devTestLabName `
+                       -maxConcurrentJobs 20
+
+# Clean up any leftover stopped VMs in the factory
+.\CleanUpFactory.ps1 -DevTestLabName $devTestLabName
+
+# Retire all 'old' images from the factory lab and all other connected labs (cascade deletes)
+.\RetireImages.ps1  -ConfigurationLocation  $configurationFilesLocation `
+                    -SubscriptionId $subscriptionId `
+                    -DevTestLabName $devTestLabName `
+                    -ImagesToSave 2

--- a/Scripts/ImageFactory/Scripts/SnapImagesFromVMs.ps1
+++ b/Scripts/ImageFactory/Scripts/SnapImagesFromVMs.ps1
@@ -4,7 +4,6 @@
     [string] $DevTestLabName
 )
 
-$ErrorActionPreference = "Stop"
 $modulePath = Join-Path (Split-Path ($Script:MyInvocation.MyCommand.Path)) "DistributionHelpers.psm1"
 Import-Module $modulePath
 
@@ -19,124 +18,114 @@ $existingImageInfos = GetImageInfosForLab $DevTestLabName
 $labVMs = Get-AzureRmResource -ResourceName $DevTestLabName -ResourceGroupName $labRgName -ResourceType 'Microsoft.DevTestLab/labs/virtualMachines' -ApiVersion '2016-05-15' | Where-Object {$_.Properties.ProvisioningState -eq 'Succeeded'}
 $jobs = @()
 $copyObjects = New-Object System.Collections.ArrayList
-try
+
+foreach($labVm in $labVMs)
 {
-
-    foreach($labVm in $labVMs)
+    #make sure we have a container in the storage account that matches the imagepath and date for this vhd
+    $imagePath = getTagValue $labVm 'ImagePath'
+    if(!$imagePath)
     {
-        #make sure we have a container in the storage account that matches the imagepath and date for this vhd
-        $imagePath = getTagValue $labVm 'ImagePath'
-        if(!$imagePath)
+        Write-Output "Ignoring $($labVm.Name) because it does not have the ImagePath tag"
+        continue
+    }
+
+    $imageName = GetImageName $imagePath
+    while ($existingImageInfos | Where-Object {$_.imageName -eq $imageName})
+    {
+        #There is an existing image with this name. We must be running the factory multiple times today. 
+        $lastChar = $imageName[$imageName.Length - 1]
+        $intVal = 0
+        if ([System.Int32]::TryParse($lastChar, [ref]$intVal))
         {
-            Write-Output "Ignoring $($labVm.Name) because it does not have the ImagePath tag"
-            continue
+            #last character is a number (probably part of the date). Append an A
+            $imageName = $imageName + 'A'
         }
-
-        $imageName = GetImageName $imagePath
-        while ($existingImageInfos | Where-Object {$_.imageName -eq $imageName})
+        else
         {
-            #There is an existing image with this name. We must be running the factory multiple times today. 
-            $lastChar = $imageName[$imageName.Length - 1]
-            $intVal = 0
-            if ([System.Int32]::TryParse($vmName, [ref]$intVal))
-            {
-                #last character is a number (probably part of the date). Append an A
-                $imageName = $imageName + 'A'
-            }
-            else
-            {
-                #last character is a letter. Increment the letter
-                $newLastChar = [char](([int]$lastChar) + 1)
-                $imageName = $imageName.SubString(0, ($imageName.Length - 1)) + $newLastChar
-            }
+            #last character is a letter. Increment the letter
+            $newLastChar = [char](([int]$lastChar) + 1)
+            $imageName = $imageName.SubString(0, ($imageName.Length - 1)) + $newLastChar
         }
+    }
 
-        $fileId = ([Guid]::NewGuid()).ToString()
+    $fileId = ([Guid]::NewGuid()).ToString()
 
-        $computeVM = Get-AzureRmVM -Status | Where-Object -FilterScript {$_.Id -eq $labVM.Properties.computeId}
+    $computeVM = Get-AzureRmVM -Status | Where-Object -FilterScript {$_.Id -eq $labVM.Properties.computeId}
     
-        if(!$computeVM)
-        {
-            Write-Error ("Didnt find a compute VM with ID " + $labVM.Properties.computeId)
-        }
+    if(!$computeVM)
+    {
+        Write-Error ("Didnt find a compute VM with ID " + $labVM.Properties.computeId)
+    }
 
-        #If the VM is still running that means it hasnt been sysprepped. dont try to copy the VHD because it will be locked.
-        if($computeVM.PowerState -and $computeVM.PowerState -eq 'VM deallocated')
+    #If the VM is still running that means it hasnt been sysprepped. dont try to copy the VHD because it will be locked.
+    if($computeVM.PowerState -and $computeVM.PowerState -eq 'VM deallocated')
+    {
+        $isReady = $true
+    }
+    else
+    {
+        $foundPowerState = $computeVM.Statuses | Where-Object {$_.Code -eq 'PowerState/deallocated'}
+        if($foundPowerState)
         {
             $isReady = $true
         }
         else
         {
-            $foundPowerState = $computeVM.Statuses | Where-Object {$_.Code -eq 'PowerState/deallocated'}
-            if($foundPowerState)
-            {
-                $isReady = $true
-            }
-            else
-            {
-                $isReady = $false
-            }
-        }
-
-        if($isReady -ne $true)
-        {
-            Write-Output ("$($labVM.Name) because it is not currently stopped/deallocated so it will not be copied") 
-            continue
-        }
-
-        #get a SAS token that's good for the next four hours. that should be enough time to complete all the disk copy jobs.
-        Write-Output "Getting SAS token for disk $($computeVM.StorageProfile.OsDisk.Name) in resource group $($computeVM.ResourceGroupName)"
-        $mdiskURL = (Grant-AzureRmDiskAccess -ResourceGroupName $computeVM.ResourceGroupName -DiskName $computeVM.StorageProfile.OsDisk.Name -Access Read -DurationInSecond 14400).AccessSAS
-        if($mdiskURL -ne $null)
-        {
-            $copyInfo = @{
-                computeRGName = $computeVM.ResourceGroupName
-                computeDiskname = $computeVM.StorageProfile.OsDisk.Name
-                sourceSASToken = $mdiskURL
-                osType = $labVM.Properties.osType
-                fileId = $fileId
-                description = $labVM.Properties.notes.Replace("Golden Image: ", "")
-                storageAcctName = $labStorageInfo.storageAcctName
-                storageAcctKey = $labStorageInfo.storageAcctKey
-                imagePath = $imagePath
-                imageName = $imageName
-            }
-
-            $copyObjects.Add($copyInfo)
-        }
-        else
-        {
-            Write-Error "Unable to get SAS token for disk $($computeVM.StorageProfile.OsDisk.Name) in resource group $($computeVM.ResourceGroupName)"
+            $isReady = $false
         }
     }
 
-    $storeVHDBlock = {
-        Param($modulePath, $copyObject)
-        Import-Module $modulePath
-        LoadProfile
+    if($isReady -ne $true)
+    {
+        Write-Output ("$($labVM.Name) because it is not currently stopped/deallocated so it will not be copied") 
+        continue
+    }
+
+    $copyInfo = @{
+        computeRGName = $computeVM.ResourceGroupName
+        computeDiskname = $computeVM.StorageProfile.OsDisk.Name
+        osType = $labVM.Properties.osType
+        fileId = $fileId
+        description = $labVM.Properties.notes.Replace("Golden Image: ", "")
+        storageAcctName = $labStorageInfo.storageAcctName
+        storageAcctKey = $labStorageInfo.storageAcctKey
+        imagePath = $imagePath
+        imageName = $imageName
+    }
+
+    $copyObjects.Add($copyInfo)
+}
+
+$storeVHDBlock = {
+    Param($modulePath, $copyObject)
+    Import-Module $modulePath
+    LoadProfile
     
-        $vhdFileName = $copyObject.fileId + ".vhd"
-        $jsonFileName = $copyObject.fileId + ".json"
-        $jsonFilePath = Join-Path $env:TEMP $jsonFileName
-        $imageName = $copyObject.imageName
-        Write-Output "Storing image: $imageName"
-        $vhdInfo = @{
-            imageName = $imageName
-            imagePath = $copyObject.imagePath
-            description = $copyObject.description
-            osType = $copyObject.osType
-            vhdFileName = $vhdFileName
-            timestamp = (Get-Date).ToUniversalTime().ToString()
-        }
+    $vhdFileName = $copyObject.fileId + ".vhd"
+    $jsonFileName = $copyObject.fileId + ".json"
+    $jsonFilePath = Join-Path $env:TEMP $jsonFileName
+    $imageName = $copyObject.imageName
+    Write-Output "Storing image: $imageName"
+    $vhdInfo = @{
+        imageName = $imageName
+        imagePath = $copyObject.imagePath
+        description = $copyObject.description
+        osType = $copyObject.osType
+        vhdFileName = $vhdFileName
+        timestamp = (Get-Date).ToUniversalTime().ToString()
+    }
     
-        ConvertTo-Json -InputObject $vhdInfo | Out-File $jsonFilePath
+    ConvertTo-Json -InputObject $vhdInfo | Out-File $jsonFilePath
+
+    try
+    {
+        Write-Output "Getting SAS token for disk $($copyObject.computeDiskname) in resource group $($copyObject.computeRGName)"
+        $mdiskURL = (Grant-AzureRmDiskAccess -ResourceGroupName $copyObject.computeRGName -DiskName $copyObject.computeDiskname -Access Read -DurationInSecond 36000).AccessSAS
 
         $storageContext = New-AzureStorageContext -StorageAccountName $copyObject.storageAcctName -StorageAccountKey $copyObject.storageAcctKey
-
-        Set-AzureStorageBlobContent -Context $storageContext -File $jsonFilePath -Container 'imagefactoryvhds'
     
         Write-Output "Starting vhd copy..."
-        $copyHandle = Start-AzureStorageBlobCopy -AbsoluteUri $copyObject.sourceSASToken -DestContainer 'imagefactoryvhds' -DestBlob $vhdFileName -DestContext $storageContext -Force
+        $copyHandle = Start-AzureStorageBlobCopy -AbsoluteUri $mdiskURL -DestContainer 'imagefactoryvhds' -DestBlob $vhdFileName -DestContext $storageContext -Force
 
         Write-Output ("Started copy of " + $copyObject.computeDiskname + " at " + (Get-Date -format "h:mm:ss tt"))
         $copyStatus = $copyHandle | Get-AzureStorageBlobCopyState 
@@ -144,60 +133,74 @@ try
 
         While($copyStatus.Status -eq "Pending"){
             $copyStatus = $copyHandle | Get-AzureStorageBlobCopyState 
-            [int]$perComplete = ($copyStatus.BytesCopied/$copyStatus.TotalBytes)*100
-            Write-Progress -Activity "Copying blob..." -status "Percentage Complete" -percentComplete "$perComplete"
+            if($copyStatus.TotalBytes)
+            {
+                [int]$perComplete = ($copyStatus.BytesCopied/$copyStatus.TotalBytes)*100
+                Write-Progress -Activity "Copying blob..." -status "Percentage Complete" -percentComplete "$perComplete"
+            }
+            else 
+            {
+                Write-Output "copyStatus.TotalBytes is not specified."
+                Write-Output $copyStatus
+            }
 
             if($perComplete -gt $statusCount){
                 $statusCount = [math]::Ceiling($perComplete) + 3
                 Write-Output "%$perComplete percent complete"
             }
+            
+            #add a message to help debug long-running copy operations that seem to hang
+            Write-Output ("Copied a total of " + $copyStatus.BytesCopied + " of " + $copyStatus.TotalBytes + " bytes")
 
-            Start-Sleep 45
+            Start-Sleep 60
         }
+
         if($copyStatus.Status -eq "Success")
         {
             Write-Output ("Successfully copied " + $copyObject.computeDiskname + " at " + (Get-Date -format "h:mm:ss tt"))
+            
+            #copy the companion .json file into the storage account next to the vhd file
+            Set-AzureStorageBlobContent -Context $storageContext -File $jsonFilePath -Container 'imagefactoryvhds'
         }
         else
         {
             if($copyStatus)
             {
                 Write-Output $copyStatus
-                Write-Error ("Copy Status should be Success but is reported as " + $copyStatus.Status)
+                Write-Error ("Copy Status for $imageName should be Success but is reported as " + $copyStatus.Status)
             }
             else
             {
                 Write-Error "There is no copy status"
             }
         }
-    }
 
-    foreach ($copyObject in $copyObjects){
-        $jobIndex++
-        Write-Output "Creating background task to store VHD $jobIndex of $($copyObjects.Count)"
-        $jobs += Start-Job -ScriptBlock $storeVHDBlock -ArgumentList $modulePath, $copyObject
     }
-    
-    if($jobs.Count -ne 0)
-    {
-        Write-Output "Waiting for VHD replication jobs to complete"
-        foreach ($job in $jobs){
-            Receive-Job $job -Wait | Write-Output
-        }
-        Remove-Job -Job $jobs
-    }
-    else 
-    {
-        Write-Output "No VHDs to replicate"
-    }
-}
-finally
-{
-    foreach ($copyObject in $copyObjects)
+    finally
     {
         Write-Output "Reverting lock on disk $($copyObject.computeDiskname) in resource group $($copyObject.computeRGName)"
         Revoke-AzureRmDiskAccess -ResourceGroupName $copyObject.computeRGName -DiskName $copyObject.computeDiskname
-        
     }
 }
+
+foreach ($copyObject in $copyObjects){
+    $jobIndex++
+    Write-Output "Creating background task to store VHD $jobIndex of $($copyObjects.Count)"
+    $jobs += Start-Job -ScriptBlock $storeVHDBlock -ArgumentList $modulePath, $copyObject
+    Start-Sleep -Seconds 3
+}
+    
+if($jobs.Count -ne 0)
+{
+    Write-Output "Waiting for VHD replication jobs to complete"
+    foreach ($job in $jobs){
+        Receive-Job $job -Wait | Write-Output
+    }
+    Remove-Job -Job $jobs
+}
+else 
+{
+    Write-Output "No VHDs to replicate"
+}
+
 Write-Output 'Finished storing sysprepped VHDs'


### PR DESCRIPTION
Add three new scripts - 
--RunImageFactory - combines the calls to the other factory scripts into one
--CleanDeploymentHistory - cleans up the deployment results for the factory lab. This is useful in larger labs where the 800 deployment limit prevents creation of more VMs
--OutputImageList - displays a list of the Images currently contained in the factory lab storage account

This checkin also includes improvments to the SnapImages script to improve reliability. The main change is that the script now creates/revokes the SAS token within the powershell job for each VM instead of managing the SAS tokens before and after all the jobs run.

It also fixes some issues with factory cleanup. In particular, if you delete a golden image json file the scripts will now delete the image(s) that were previously created for that image.
