### PR TITLE
Improve logging when deployment fails

### DIFF
--- a/VstsTasks/AzureDtlCreateVM/task-funcs.ps1
+++ b/VstsTasks/AzureDtlCreateVM/task-funcs.ps1
@@ -152,7 +152,7 @@ function Get-AzureDtlDeploymentTargetResourceId
         }
     }
 
-    if (-not $targetResource)
+    if ([string]::IsNullOrEmpty($targetResource.id))
     {
         $null = @(
             Write-Host "Dumping resource group deployment operation details for $ResourceGroupName/$DeploymentName`:"

--- a/VstsTasks/AzureDtlCreateVM/task.json
+++ b/VstsTasks/AzureDtlCreateVM/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 6
+        "Patch": 7
     },
     "demands": [
         "azureps"

--- a/VstsTasks/AzureDtlCreateVM/task.ps1
+++ b/VstsTasks/AzureDtlCreateVM/task.ps1
@@ -123,7 +123,14 @@ try
             else
             {
                 Write-Host "A deployment failure occured. Retrying deployment (attempt $i of $($count - 1))"
-                Remove-AzureRmResource -ResourceId $resourceId -Force | Out-Null
+                if ($resourceId)
+                {
+                    Remove-AzureRmResource -ResourceId $resourceId -Force | Out-Null
+                }
+                else
+                {
+                    Write-Host "Resource identifier is not available, will not attempt to remove corresponding resouce before retrying."
+                }
             }
         }
     }

--- a/VstsTasks/vss-extension.json
+++ b/VstsTasks/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "tasks",
-    "version": "1.0.17",
+    "version": "1.0.18",
     "name": "Azure DevTest Labs Tasks",
     "publisher": "ms-azuredevtestlabs",
     "description": "Collection of build/release tasks to interact with Azure DevTest Labs.",


### PR DESCRIPTION
- Added more logging when the resource identifier is not found after a deployment fails.
- Do not attempt to remove the failed resource, when retrying, if the resource identifier is not found.