### PR TITLE
Update VS2015 image reference

### DIFF
--- a/Scripts/ImageFactory/Configuration/GoldenImages/Win2012R2/VS2015 Enterprise with Azure SDK.json
+++ b/Scripts/ImageFactory/Configuration/GoldenImages/Win2012R2/VS2015 Enterprise with Azure SDK.json
@@ -37,7 +37,7 @@
         "galleryImageReference": {
           "offer": "VisualStudio",
           "publisher": "MicrosoftVisualStudio",
-          "sku": "VS-2015-Ent-VSU3-AzureSDK-291-WS2012R2",
+          "sku": "VS-2015-Ent-VSU3-AzureSDK-29-WS2012R2",
           "osType": "Windows",
           "version": "latest"
         },


### PR DESCRIPTION
Partially resolves #294 for the VS2015 Enterprise with Azure SDK image. 

Unless another image is made available in the marketplace, the SQL Server image would need to use SQL Server 2014 (+file rename to match) or be upgraded to Win2016 and moved to the other folder.