### PR TITLE
Fix broken linux artifacts 

### DIFF
--- a/Artifacts/linux-install-mongodb/linux_install_mongodb_v1.sh
+++ b/Artifacts/linux-install-mongodb/linux_install_mongodb_v1.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-set -e
-
 isApt=`command -v apt-get`
 isYum=`command -v yum`
+
+# The above commands may error on some flavors depending on which installation mechanism is available.
+# So move the set -e command here
+set -e
 
 if [ -n "$isApt" ] ; then
     echo "Using APT package manager"

--- a/Artifacts/linux-install-mongodb/linux_install_mongodb_v1.sh
+++ b/Artifacts/linux-install-mongodb/linux_install_mongodb_v1.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "Installing MongoDb"
+
 isApt=`command -v apt-get`
 isYum=`command -v yum`
 

--- a/Artifacts/linux-install-mongodb/linux_install_mongodb_v1.sh
+++ b/Artifacts/linux-install-mongodb/linux_install_mongodb_v1.sh
@@ -5,8 +5,8 @@ echo "Installing MongoDb"
 isApt=`command -v apt-get`
 isYum=`command -v yum`
 
-# The above commands may error on some flavors depending on which installation mechanism is available.
-# So move the set -e command here
+# Some of the previous commands will fail with an exit code other than zero (intentionally), 
+# so we do not set error handling to stop (set e) until after they've run
 set -e
 
 if [ -n "$isApt" ] ; then

--- a/Artifacts/linux-install-nodejs/linux_install_nodejs_v1.sh
+++ b/Artifacts/linux-install-nodejs/linux_install_nodejs_v1.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-set -e
+echo "Installing NodeJs"
 
 isApt=`command -v apt-get`
 isYum=`command -v yum`
+
+# The above commands may error on some flavors depending on which installation mechanism is available.
+# So move the set -e command here
+set -e
 
 if [ -n "$isApt" ] ; then
     echo "Using APT package manager"

--- a/Artifacts/linux-install-nodejs/linux_install_nodejs_v1.sh
+++ b/Artifacts/linux-install-nodejs/linux_install_nodejs_v1.sh
@@ -5,8 +5,8 @@ echo "Installing NodeJs"
 isApt=`command -v apt-get`
 isYum=`command -v yum`
 
-# The above commands may error on some flavors depending on which installation mechanism is available.
-# So move the set -e command here
+# Some of the previous commands will fail with an exit code other than zero (intentionally), 
+# so we do not set error handling to stop (set e) until after they've run
 set -e
 
 if [ -n "$isApt" ] ; then

--- a/Artifacts/linux-java/linux_install_jdk.sh
+++ b/Artifacts/linux-java/linux_install_jdk.sh
@@ -8,10 +8,14 @@
 # Author Darren Rich <darrich@microsoft.com>
 # Original version found on VSTS: https://almrangers.visualstudio.com/
 
-set -e
+echo "Installing Java"
 
 isApt=`command -v apt-get`
 isYum=`command -v yum`
+
+# The above commands may error on some flavors depending on which installation mechanism is available.
+# So move the set -e command here
+set -e
 
 if [ -n "$isApt" ] ; then
     echo "Using APT package manager"

--- a/Artifacts/linux-java/linux_install_jdk.sh
+++ b/Artifacts/linux-java/linux_install_jdk.sh
@@ -13,8 +13,8 @@ echo "Installing Java"
 isApt=`command -v apt-get`
 isYum=`command -v yum`
 
-# The above commands may error on some flavors depending on which installation mechanism is available.
-# So move the set -e command here
+# Some of the previous commands will fail with an exit code other than zero (intentionally), 
+# so we do not set error handling to stop (set e) until after they've run
 set -e
 
 if [ -n "$isApt" ] ; then


### PR DESCRIPTION
Artifacts were broken because set -e was set too early in the script. As some of the commands in the script are expected to fail.