### PR TITLE
Passing VM OS information as object parameter

### DIFF
--- a/VstsTasks/AzureDtlCreateCustomImage/new-azuredtl-customimage.json
+++ b/VstsTasks/AzureDtlCreateCustomImage/new-azuredtl-customimage.json
@@ -8,34 +8,8 @@
         "labName": {
             "type": "string"
         },
-        "sourceLabVmId": {
-            "type": "string"
-        },
-        "osType": {
-            "type": "string",
-            "allowedValues": [
-                "Linux",
-                "Windows"
-            ],
-            "defaultValue": "Windows"
-        },
-        "linuxOsState": {
-            "type": "string",
-            "allowedValues": [
-                "NonDeprovisioned",
-                "DeprovisionRequested",
-                "DeprovisionApplied"
-            ],
-            "defaultValue": "NonDeprovisioned"
-        },
-        "windowsOsState": {
-            "type": "string",
-            "allowedValues": [
-                "NonSysprepped",
-                "SysprepRequested",
-                "SysprepApplied"
-            ],
-            "defaultValue": "NonSysprepped"
+        "vmOsInfo": {
+            "type": "object"
         },
         "description": {
             "type": "string",
@@ -59,16 +33,7 @@
             "properties": {
                 "author": "[parameters('author')]",
                 "description": "[parameters('description')]",
-                "osType": "[parameters('osType')]",
-                "vm": {
-                    "sourceVmId": "[parameters('sourceLabVmId')]",
-                    "linuxOsInfo":  {
-                        "linuxOsState": "[parameters('linuxOsState')]"
-                    },
-                    "windowsOsInfo": {
-                        "windowsOsState": "[parameters('windowsOsState')]"
-                    }
-                }
+                "vm": "[parameters('vmOsInfo')]"
             }
         }
     ],

--- a/VstsTasks/AzureDtlCreateCustomImage/task.json
+++ b/VstsTasks/AzureDtlCreateCustomImage/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 18
+        "Patch": 20
     },
     "demands": [
         "azureps"

--- a/VstsTasks/AzureDtlCreateCustomImage/task.ps1
+++ b/VstsTasks/AzureDtlCreateCustomImage/task.ps1
@@ -11,7 +11,6 @@
     - N/A.    
 
 ##################################################################################################>
-
 #
 # Parameters to this script file.
 #
@@ -30,7 +29,6 @@ param(
 )
 
 ###################################################################################################
-
 #
 # Required modules.
 #
@@ -39,7 +37,6 @@ Import-Module Microsoft.TeamFoundation.DistributedTask.Task.Common
 Import-Module Microsoft.TeamFoundation.DistributedTask.Task.Internal
 
 ###################################################################################################
-
 #
 # PowerShell configurations
 #
@@ -52,7 +49,6 @@ $ErrorActionPreference = "Stop"
 pushd $PSScriptRoot
 
 ###################################################################################################
-
 #
 # Functions used in this script.
 #
@@ -60,7 +56,6 @@ pushd $PSScriptRoot
 .".\task-funcs.ps1"
 
 ###################################################################################################
-
 #
 # Handle all errors in this script.
 #
@@ -73,7 +68,6 @@ trap
 }
 
 ###################################################################################################
-
 #
 # Main execution block.
 #
@@ -81,7 +75,7 @@ trap
 try
 {
     Write-Host 'Starting Azure DevTest Labs Create Custom Image Task'
-
+    
     Show-InputParameters
 
     $lab = Get-AzureDtlLab -LabId "$LabId"

--- a/VstsTasks/vss-extension.json
+++ b/VstsTasks/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "tasks",
-    "version": "1.0.19",
+    "version": "1.0.21",
     "name": "Azure DevTest Labs Tasks",
     "publisher": "ms-azuredevtestlabs",
     "description": "Collection of build/release tasks to interact with Azure DevTest Labs.",


### PR DESCRIPTION
Updated approach used to set the VM OS information when preparing the request to create the custom image.

Before, we used the osType to distinguish in the RP and choose either the linuxOsState or windowsOsState. We have since moved to simply check if the OS State object is present and default to the Windows OS State check first. So, if both objects are passed, which is what we did before, we take Windows even though the OS Type was set to Linux. Therefore, I have change the logic in the task to ensure we only pass the corresponding OS State based on the OS Type. We do the same thing from the Azure Portal logic. I matched that logic.