### PR TITLE
Fixing service init/start incompatibility with SLES 11

### DIFF
--- a/Artifacts/linux-deprovision/depro.sh
+++ b/Artifacts/linux-deprovision/depro.sh
@@ -15,10 +15,17 @@ main () {
             yum install -y at > /dev/null
         elif [ -n "$isZypper" ] ; then
             zypper install -y at > /dev/null
-            systemctl enable atd.service && systemctl start atd.service
         else
             echo 'OS type not supported' #> /dev/null 2>&1
             exit 1
+        fi
+
+        # Make sure that the atd service is running to cover our dependency below.
+        isSystemctl=`command -v systemctl`
+        if [ -n "$isSystemctl" ] ; then
+            systemctl enable atd.service && systemctl start atd.service > /dev/null
+        else
+            insserv atd && /etc/init.d/atd start > /dev/null
         fi
 
         # chdir to waagent's directory before running it


### PR DESCRIPTION
Adding logic to fall back to "System V" to initialize services, instead of relying purely on "systemd", which is only installed on later flavors of Linux.