### PR TITLE
VSTS Build Agent artifact Swapped to System.IO.Compression.FileSystem to extract file

### DIFF
--- a/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
+++ b/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
@@ -220,9 +220,10 @@ function Extract-AgentPackage
         [string] $PackagePath,
         [string] $Destination
     )
+  
+    Add-Type -AssemblyName System.IO.Compression.FileSystem 
+    [System.IO.Compression.ZipFile]::ExtractToDirectory("$PackagePath", "$Destination")
     
-    $destShellFolder = (New-Object -ComObject shell.application).namespace("$Destination")
-    $destShellFolder.CopyHere((New-Object -ComObject shell.application).namespace($PackagePath).Items(), 16)
 }
 
 function Install-Agent


### PR DESCRIPTION
This is a fix for issue #318 - that the VSTS build agent artifact fails to deploy on a non GUI Windows Server VM.

Swapped to using **System.IO.Compression.FileSystem** as opposed to **New-Object -ComObject shell.application** call.

I have tested this on using my DevTest Labs instance using my fork as a private repo and it deploys without error