### PR TITLE
Remove yum update line

### DIFF
--- a/Artifacts/linux-deprovision/depro.sh
+++ b/Artifacts/linux-deprovision/depro.sh
@@ -11,7 +11,6 @@ main () {
             apt-get -y update > /dev/null
             apt-get -y install at > /dev/null
         elif [ -n "$isYum" ] ; then
-            yum -y update > /dev/null
             yum install -y at > /dev/null
         elif [ -n "$isZypper" ] ; then
             zypper install -y at > /dev/null


### PR DESCRIPTION
Running yum update then [updates ](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/update-infrastructure-redhat) the version of Red Hat and breaks deprovision.  Removed this line as to not cause side effects when running deprovision.

Have tested on linux flavors with yum that existing functionality is not broken.