### PR TITLE
Add message in description for CoreOS

### DIFF
--- a/Artifacts/linux-deprovision/Artifactfile.json
+++ b/Artifacts/linux-deprovision/Artifactfile.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
     "title": "de-provision",
-    "description": "Uses the Microsoft Azure Linux Agent (waagent) to de-provision a Linux VM for saving as an image.  This artifact does not work on the Core OS flavor of Linux..",
+    "description": "Uses the Microsoft Azure Linux Agent (waagent) to de-provision a Linux VM for saving as an image.  This artifact does not work on the Core OS or FreeBSD flavors of Linux.",
     "publisher": "Microsoft",
     "tags": [
         "Linux"

--- a/Artifacts/linux-deprovision/Artifactfile.json
+++ b/Artifacts/linux-deprovision/Artifactfile.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
     "title": "de-provision",
-    "description": "Uses the Microsoft Azure Linux Agent (waagent) to de-provision a Linux VM for saving as an image.",
+    "description": "Uses the Microsoft Azure Linux Agent (waagent) to de-provision a Linux VM for saving as an image.  This artifact does not work on the Core OS flavor of Linux..",
     "publisher": "Microsoft",
     "tags": [
         "Linux"


### PR DESCRIPTION
CoreOS deprovision does not work, and it is not a very popular flavor in DTL so we will postpone the investment to support it.  We however will add a warning in the artifact description so potential customers will know.