### PR TITLE
Make OU path optional in Windows AD join

### DIFF
--- a/Artifacts/windows-domain-join-new/Artifactfile.json
+++ b/Artifacts/windows-domain-join-new/Artifactfile.json
@@ -27,7 +27,9 @@
     "ouPath": {
       "type": "string",
       "displayName": "Active Directory (AD) domain OU",
-      "description": "The OU path e.g. OU=Workstations,OU=Machines,DC=corp,DC=contoso,DC=com"
+      "description": "The OU path e.g. OU=Workstations,OU=Machines,DC=corp,DC=contoso,DC=com",
+      "allowEmpty": true,
+      "defaultValue": ""
     }
   },
   "runCommand": {

--- a/Artifacts/windows-domain-join-new/artifact.ps1
+++ b/Artifacts/windows-domain-join-new/artifact.ps1
@@ -10,7 +10,7 @@ param
     [Parameter(Mandatory = $true)]
     [string] $DomainToJoin,
 
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [string] $OUPath
 )
 
@@ -20,19 +20,19 @@ function Add-VmToDomain ()
 {
     param
     (
-        [Parameter(Mandatory = $true)] 
-        [string] $VmName, 
-        
-        [Parameter(Mandatory = $true)] 
-        [string] $DomainName, 
-        
-        [Parameter(Mandatory = $true)] 
-        [string] $JoinUser, 
-        
-        [Parameter(Mandatory = $true)] 
-        [securestring] $JoinPassword, 
-        
-        [Parameter(Mandatory = $true)] 
+        [Parameter(Mandatory = $true)]
+        [string] $VmName,
+
+        [Parameter(Mandatory = $true)]
+        [string] $DomainName,
+
+        [Parameter(Mandatory = $true)]
+        [string] $JoinUser,
+
+        [Parameter(Mandatory = $true)]
+        [securestring] $JoinPassword,
+
+        [Parameter(Mandatory = $false)]
         [string] $OU
     )
 
@@ -68,6 +68,10 @@ else
 {
     $securePass = ConvertTo-SecureString $DomainAdminPassword -AsPlainText -Force
     Write-Output "Attempting to join the domain..."
+    # Treat empty string as null to convert to optional parameter
+    if(-not $OUPath) {
+        $OUPath = $null
+    }
     Add-VmToDomain -VmName $env:COMPUTERNAME -DomainName $DomainToJoin -JoinUser $DomainAdminUsername -JoinPassword $securePass -OU $OUPath
 }
 


### PR DESCRIPTION
Makes OU path an optional argument when attempting to domain join a machine. Requiring an OU path is not often necessary and is too restrictive when AD permissions do not allow specific OU joining.