### PR TITLE
Fix domain join null argument exception

### DIFF
--- a/Artifacts/windows-domain-join-new/artifact.ps1
+++ b/Artifacts/windows-domain-join-new/artifact.ps1
@@ -43,8 +43,11 @@ function Add-VmToDomain ()
     else
     {
         $credential = New-Object System.Management.Automation.PSCredential($JoinUser, $JoinPassword)
-    
-        [Microsoft.PowerShell.Commands.ComputerChangeInfo]$computerChangeInfo = Add-Computer -ComputerName $VmName -DomainName $DomainName -Credential $credential -OUPath $OU -Force -PassThru
+        if($OU) {   
+            [Microsoft.PowerShell.Commands.ComputerChangeInfo]$computerChangeInfo = Add-Computer -ComputerName $VmName -DomainName $DomainName -Credential $credential -OUPath $OU -Force -PassThru
+        } else {
+            [Microsoft.PowerShell.Commands.ComputerChangeInfo]$computerChangeInfo = Add-Computer -ComputerName $VmName -DomainName $DomainName -Credential $credential -Force -PassThru
+        }
         if ($computerChangeInfo.HasSucceeded)
         {
             Write-Output "Result: Successfully joined the $DomaintoJoin domain"
@@ -68,10 +71,6 @@ else
 {
     $securePass = ConvertTo-SecureString $DomainAdminPassword -AsPlainText -Force
     Write-Output "Attempting to join the domain..."
-    # Treat empty string as null to convert to optional parameter
-    if(-not $OUPath) {
-        $OUPath = $null
-    }
     Add-VmToDomain -VmName $env:COMPUTERNAME -DomainName $DomainToJoin -JoinUser $DomainAdminUsername -JoinPassword $securePass -OU $OUPath
 }
 


### PR DESCRIPTION
The command `Add-Computer` expects non-null arguments when invoked. When calling windows domain join, this can result in a null argument exception when the OUPath is not specified.

Related to previous change #340.