### PR TITLE
Fixes #342 - Renamed ARMTemplates folder to Samples

### DIFF
--- a/Samples/101-dtl-create-blockchain-lab/README.md
+++ b/Samples/101-dtl-create-blockchain-lab/README.md
@@ -1,6 +1,6 @@
 # Create a new DevTest Labs instance for Azure Blockchain as a Service
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F101-dtl-create-lab%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F101-dtl-create-lab%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/101-dtl-create-vm-builtin-user/README.md
+++ b/Samples/101-dtl-create-vm-builtin-user/README.md
@@ -1,6 +1,6 @@
 # Create a new virtual machine in a DevTestLab instance.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F101-dtl-create-vm-builtin-user%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FSamples%2F101-dtl-create-vm-builtin-user%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/101-dtl-create-vm-username-pwd-customimage-with-expiration/README.md
+++ b/Samples/101-dtl-create-vm-username-pwd-customimage-with-expiration/README.md
@@ -1,6 +1,6 @@
 # Creates a new virtual machine in a Lab with a specified expiration date.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F101-dtl-create-vm-username-pwd-customimage-with-expiration%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FSamples%2F101-dtl-create-vm-username-pwd-customimage-with-expiration%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/101-dtl-create-vm-username-pwd-customimage/README.md
+++ b/Samples/101-dtl-create-vm-username-pwd-customimage/README.md
@@ -1,6 +1,6 @@
 # Create a new virtual machine in a DevTestLab instance.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F101-dtl-create-vm-username-pwd-customimage%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FSamples%2F101-dtl-create-vm-username-pwd-customimage%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/101-dtl-create-vm-username-pwd-galleryimage/README.md
+++ b/Samples/101-dtl-create-vm-username-pwd-galleryimage/README.md
@@ -1,6 +1,6 @@
 # Create a new virtual machine in a DevTestLab instance.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F101-dtl-create-vm-username-pwd-galleryimage%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F101-dtl-create-vm-username-pwd-galleryimage%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/101-dtl-create-vm-username-ssh-customimage/README.md
+++ b/Samples/101-dtl-create-vm-username-ssh-customimage/README.md
@@ -1,6 +1,6 @@
 # Create a new virtual machine in a DevTestLab instance.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F101-dtl-create-vm-username-ssh-customimage%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F101-dtl-create-vm-username-ssh-customimage%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/101-dtl-create-vm-username-ssh-galleryimage/README.md
+++ b/Samples/101-dtl-create-vm-username-ssh-galleryimage/README.md
@@ -1,6 +1,6 @@
 # Create a new virtual machine in a DevTestLab instance.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F101-dtl-create-vm-username-ssh-galleryimage%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F101-dtl-create-vm-username-ssh-galleryimage%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/201-dtl-create-customimage-from-linux-vm/README.md
+++ b/Samples/201-dtl-create-customimage-from-linux-vm/README.md
@@ -1,6 +1,6 @@
 # Create a new Custom Image from a Linux VM.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F201-dtl-create-customimage-from-linux-vm%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FSamples%2F201-dtl-create-customimage-from-linux-vm%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/201-dtl-create-customimage-from-vhd/README.md
+++ b/Samples/201-dtl-create-customimage-from-vhd/README.md
@@ -1,6 +1,6 @@
 # Create a new Custom Image from a VHD.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F201-dtl-create-customimage-from-vhd%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F201-dtl-create-customimage-from-vhd%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/201-dtl-create-customimage-from-windows-vm/README.md
+++ b/Samples/201-dtl-create-customimage-from-windows-vm/README.md
@@ -1,6 +1,6 @@
 # Create a new Custom Image from a Windows VM.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F201-dtl-create-customimage-from-windows-vm%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-devtestlab%2Fmaster%2FSamples%2F201-dtl-create-customimage-from-windows-vm%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/201-dtl-create-formula/README.md
+++ b/Samples/201-dtl-create-formula/README.md
@@ -1,6 +1,6 @@
 # Create a new DevTest Lab formula
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F201-dtl-create-formula%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F201-dtl-create-formula%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/201-dtl-create-lab-with-artifact-repository/README.md
+++ b/Samples/201-dtl-create-lab-with-artifact-repository/README.md
@@ -1,6 +1,6 @@
 # Create a new DevTestLab instance
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F201-dtl-create-lab-with-artifact-repository%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F201-dtl-create-lab-with-artifact-repository%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/201-dtl-create-lab-with-cost-threshold/README.md
+++ b/Samples/201-dtl-create-lab-with-cost-threshold/README.md
@@ -1,6 +1,6 @@
 # Create a new DevTestLab instance
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F201-dtl-create-lab-with-policies%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F201-dtl-create-lab-with-policies%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/201-dtl-create-lab-with-marketplace-images/README.md
+++ b/Samples/201-dtl-create-lab-with-marketplace-images/README.md
@@ -1,6 +1,6 @@
 # Create a new DevTestLab instance
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F201-dtl-create-lab-with-policies%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F201-dtl-create-lab-with-policies%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/201-dtl-create-lab-with-policies/README.md
+++ b/Samples/201-dtl-create-lab-with-policies/README.md
@@ -1,6 +1,6 @@
 # Create a new DevTestLab instance
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F201-dtl-create-lab-with-policies%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F201-dtl-create-lab-with-policies%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/201-dtl-create-lab-with-shutdown-webhook/README.md
+++ b/Samples/201-dtl-create-lab-with-shutdown-webhook/README.md
@@ -1,6 +1,6 @@
 # Create a new DevTestLab instance
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F201-dtl-create-lab-with-policies%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F201-dtl-create-lab-with-policies%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/201-dtl-enable-autostart/README.md
+++ b/Samples/201-dtl-enable-autostart/README.md
@@ -1,6 +1,6 @@
 # Enable Auto Start
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F201-dtl-enable-autostart%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F201-dtl-enable-autostart%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/301-dtl-add-lab-user/readme.md
+++ b/Samples/301-dtl-add-lab-user/readme.md
@@ -1,6 +1,6 @@
 # Add Lab User to a DevTestLab instance
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F301-dtl-add-lab-user%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F301-dtl-add-lab-user%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/Samples/301-dtl-create-lab-with-existing-vnet/README.md
+++ b/Samples/301-dtl-create-lab-with-existing-vnet/README.md
@@ -1,6 +1,6 @@
 # Create a new DevTestLab instance
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FARMTemplates%2F301-dtl-create-lab-with-existing-vnet%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FSamples%2F301-dtl-create-lab-with-existing-vnet%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 


### PR DESCRIPTION
This fixes the problem seen by Robert Komara that the "Deploy to Azure" buttons are referencing the old ARMTemplates folder where the samples used to be