### PR TITLE
Resetting value used for labVmId before each retry

### DIFF
--- a/VstsTasks/AzureDtlCreateVM/task.json
+++ b/VstsTasks/AzureDtlCreateVM/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 26
+        "Patch": 27
     },
     "demands": [
         "azureps"

--- a/VstsTasks/AzureDtlCreateVM/task.ps1
+++ b/VstsTasks/AzureDtlCreateVM/task.ps1
@@ -126,6 +126,9 @@ try
             }
             else
             {
+                # Reset $resourceId to ensure we don't mistakenly return a previously invalid value in case of a subsequent retry error.
+                $resourceId = ''
+
                 Write-Host "##vso[task.logissue type=warning;]A deployment failure occured. Retrying deployment (attempt $i of $($count - 1))"
                 Remove-FailedResourcesBeforeRetry -DeploymentName $deploymentName -ResourceGroupName $resourceGroupName -DeleteDeployment $DeleteFailedDeploymentBeforeRetry
                 $appendSuffix = ConvertTo-Bool -Value $AppendRetryNumberToVMName

--- a/VstsTasks/vss-extension.json
+++ b/VstsTasks/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "tasks",
-    "version": "1.0.40",
+    "version": "1.0.41",
     "name": "Azure DevTest Labs Tasks",
     "publisher": "ms-azuredevtestlabs",
     "description": "Collection of build/release tasks to interact with Azure DevTest Labs.",


### PR DESCRIPTION
Reset $resourceId to ensure we don't mistakenly return a previously invalid value in case of a subsequent retry error.