### PR TITLE
expose skipDos2Unix in the linux-run-bash artifact

### DIFF
--- a/Artifacts/linux-run-bash/Artifactfile.json
+++ b/Artifacts/linux-run-bash/Artifactfile.json
@@ -24,6 +24,13 @@
             "displayName": "Script Arguments",
             "description": "Script arguments to pass",
             "allowEmpty": true
+        },
+        "skipDos2Unix": {
+            "type": "bool",
+            "displayName": "Convert script from MSDOS to Unix line ending",
+            "description": "Script arguments to pass",
+            "allowEmpty": true,
+            "defaultValue": "true"
         }
     },
     "runAzureVMExtension": {
@@ -32,7 +39,8 @@
         "typeHandlerVersion": "2.0",
         "settings": {
             "fileUris": "[parameters('scriptFileUris')]",
-            "commandToExecute": "[concat('sh', ' ', parameters('scriptToRun'), ' ', parameters('scriptArguments'))]"
+            "commandToExecute": "[concat('sh', ' ', parameters('scriptToRun'), ' ', parameters('scriptArguments'))]",
+            "skipDos2Unix": "[parameters('skipDos2Unix')]"
         }
     }
 }

--- a/Artifacts/linux-run-bash/Artifactfile.json
+++ b/Artifacts/linux-run-bash/Artifactfile.json
@@ -27,8 +27,8 @@
         },
         "skipDos2Unix": {
             "type": "bool",
-            "displayName": "Convert script from MSDOS to Unix line ending",
-            "description": "Script arguments to pass",
+            "displayName": "Skip dos2unix conversion",
+            "description": "Skip the script conversion from MSDOS to Unix line ending",
             "allowEmpty": true,
             "defaultValue": "true"
         }


### PR DESCRIPTION
The linux-run-bash artifact does not expose the skipDos2Unix parameters, and its value is always 'false'. If you use the linux-run-bash artifact with a shell script that contains binary data appended at the end, you want to avoid to run the 'dos2unix' tool, and you want to avoid any manipulation of the downloaded file. It must be used as is, not conversion of its content at all.

Exposing this parameter allow to avoid any conversion of the downloaded script.