### PR TITLE
Build definition ID

### DIFF
--- a/Artifacts/windows-vsts-download-and-run-script/DownloadVstsDropAndExecuteScript.ps1
+++ b/Artifacts/windows-vsts-download-and-run-script/DownloadVstsDropAndExecuteScript.ps1
@@ -4,7 +4,8 @@ param(
     [string] $buildDefinitionName,
     [string] $vstsProjectUri,
     [string] $pathToScript,
-    [string] $scriptArguments
+    [string] $scriptArguments,
+    [string] $buildDefId
 )
 
 ###################################################################################################
@@ -102,11 +103,20 @@ function Get-BuildDefinitionId
 
     Write-Host "Getting build definition ID from $BuildDefinitionUri"
     $buildDef = Invoke-RestMethod -Uri $BuildDefinitionUri -Headers $Headers -Method Get
-    $buildDefinitionId = $buildDef.value.id
-    if (-not $buildDefinitionId)
+    if (-not $buildDefId)
     {
-        throw "Unable to get the build definition ID from $buildDefinitionUri"
+     $buildDefinitionId = $buildDef.value.id[0]
+     if (-not $buildDefinitionId)
+      {
+          throw "Unable to get the build definition ID from $buildDefinitionUri"
+      }
     }
+    else
+    {
+        $buildDefinitionId = $buildDefId
+    }
+    
+   
 
     return $buildDefinitionId
 }


### PR DESCRIPTION
Add parameter to specify build definition id. If the id is not present the api will default to the first build definition