### PR TITLE
Azure DevOps Pipelines Agent - multiple instances in single DTL VM

### DIFF
--- a/Artifacts/windows-azuredevops-multiple-agents/artifactfile.json
+++ b/Artifacts/windows-azuredevops-multiple-agents/artifactfile.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
+    "title": "Azure Pipelines Multiple Agents",
+    "publisher": "onlyutkarsh",
+    "description": "Downloads latest Azure Pipelines agent, and creates the specified instances of the agents inside the specified VM. Registers the agent with the specified Azure DevOps account, and adds agents to the specified agent pool. Note - If the specified agent already exists it will be overwritten.",
+    "tags": [
+      "Azure DevOps",
+      "Pipelines",
+      "Release",
+      "Build",
+      "CI",
+      "Windows"
+    ],
+    "iconUri": "https://cdn.vsassets.io/content/icons/favicon.ico",
+    "targetOsType": "Windows",
+    "parameters": {
+      "Account": {
+        "type": "string",
+        "displayName": "Azure DevOps Account Name",
+        "description": "The name of the Azure DevOps account to add the build agent to. This is the value in your Azure DevOps URL: e.g. 'myaccount' in https://dev.azure.com/myaccount."
+      },
+      "PersonalAccessToken": {
+        "type": "securestring",
+        "displayName": "Azure DevOps Personal Access Token",
+        "description": "A personal access token with permissions to add build agents. It will only be used to register the agent."
+      },
+      "AgentName": {
+        "type": "string",
+        "displayName": "Agent Name",
+        "description": "The name to give to the agent, as seen by Azure DevOps. If empty, the computer name will be used. Prefixes every agent with given prefix",
+        "allowEmpty": true
+      },
+      "AgentNamePrefix": {
+        "type": "string",
+        "displayName": "Agent Name Prefix",
+        "description": "Prefixes every agent with string specified here",
+        "allowEmpty": true
+      },
+      "PoolName": {
+        "type": "string",
+        "displayName": "Agent Pool",
+        "description": "The agent pool this build agent should be added to."
+      },
+      "AgentCount":{
+        "type": "int",
+        "displayName": "Number of Agents",
+        "description": "The number of agents to install and add to the pool. Each agent will be named as prefix-agentname-(1..n)."
+      }
+    },
+    "runCommand": {
+      "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./run.ps1',' -Account ', parameters('Account'), ' -PersonalAccessToken ', parameters('PersonalAccessToken'), ' -AgentName ''', parameters('AgentName'), ''' -AgentNamePrefix ''', parameters('AgentNamePrefix'), ''' -PoolName ''', parameters('PoolName'), ''' -AgentCount ''', parameters('AgentCount'), '''\"')]"
+    }
+  }

--- a/Artifacts/windows-azuredevops-multiple-agents/artifactfile.json
+++ b/Artifacts/windows-azuredevops-multiple-agents/artifactfile.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
-    "title": "Azure Pipelines Multiple Agents",
-    "publisher": "onlyutkarsh",
-    "description": "Downloads latest Azure Pipelines agent, and creates the specified instances of the agents inside the specified VM. Registers the agent with the specified Azure DevOps account, and adds agents to the specified agent pool. Note - If the specified agent already exists it will be overwritten.",
+    "title": "Azure Pipelines Agent(s)",
+    "publisher": "Utkarsh Shigihalli",
+    "description": "Downloads latest Azure Pipelines agent for the account, and installs the specified number instances of the agents inside one VM. Registers the agent with the Azure DevOps account, and adds agents to the specified agent pool. Note - If the specified agent folder already exists it will be overwritten.",
     "tags": [
       "Azure DevOps",
       "Pipelines",

--- a/Artifacts/windows-azuredevops-multiple-agents/artifactfile.json
+++ b/Artifacts/windows-azuredevops-multiple-agents/artifactfile.json
@@ -2,52 +2,65 @@
     "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
     "title": "Azure Pipelines Agent(s)",
     "publisher": "Utkarsh Shigihalli",
-    "description": "Downloads latest Azure Pipelines agent for the account, and installs the specified number instances of the agents inside one VM. Registers the agent with the Azure DevOps account, and adds agents to the specified agent pool. Note - If the specified agent folder already exists it will be overwritten.",
+    "description": "Downloads latest Azure Pipelines agent for the account, and installs the specified number instances of the agents inside one Windows VM. Registers the agent with the Azure DevOps account, and adds agents to the specified agent pool. Note - If the specified agent folder already exists it will be overwritten.",
     "tags": [
-      "Azure DevOps",
-      "Pipelines",
-      "Release",
-      "Build",
-      "CI",
-      "Windows"
+        "Azure DevOps",
+        "Pipelines",
+        "Release",
+        "Build",
+        "CI",
+        "Windows"
     ],
     "iconUri": "https://cdn.vsassets.io/content/icons/favicon.ico",
     "targetOsType": "Windows",
     "parameters": {
-      "Account": {
-        "type": "string",
-        "displayName": "Azure DevOps Account Name",
-        "description": "The name of the Azure DevOps account to add the build agent to. This is the value in your Azure DevOps URL: e.g. 'myaccount' in https://dev.azure.com/myaccount."
-      },
-      "PersonalAccessToken": {
-        "type": "securestring",
-        "displayName": "Azure DevOps Personal Access Token",
-        "description": "A personal access token with permissions to add build agents. It will only be used to register the agent."
-      },
-      "AgentName": {
-        "type": "string",
-        "displayName": "Agent Name",
-        "description": "The name to give to the agent, as seen by Azure DevOps. If empty, the computer name will be used. Prefixes every agent with given prefix",
-        "allowEmpty": true
-      },
-      "AgentNamePrefix": {
-        "type": "string",
-        "displayName": "Agent Name Prefix",
-        "description": "Prefixes every agent with string specified here",
-        "allowEmpty": true
-      },
-      "PoolName": {
-        "type": "string",
-        "displayName": "Agent Pool",
-        "description": "The agent pool this build agent should be added to."
-      },
-      "AgentCount":{
-        "type": "int",
-        "displayName": "Number of Agents",
-        "description": "The number of agents to install and add to the pool. Each agent will be named as prefix-agentname-(1..n)."
-      }
+        "Account": {
+            "type": "string",
+            "displayName": "Azure DevOps Account Name",
+            "description": "The name of the Azure DevOps account to add the build agent to. This is the value in your Azure DevOps URL: e.g. 'myaccount' in https://dev.azure.com/myaccount."
+        },
+        "PersonalAccessToken": {
+            "type": "securestring",
+            "displayName": "Azure DevOps Personal Access Token",
+            "description": "A personal access token with permissions to add build agents. It will only be used to register the agent."
+        },
+        "AgentName": {
+            "type": "string",
+            "displayName": "Agent Name",
+            "description": "The name to give to the agent, as seen by Azure DevOps. If empty, the computer name will be used.",
+            "allowEmpty": true
+        },
+        "AgentNamePrefix": {
+            "type": "string",
+            "displayName": "Agent Name Prefix",
+            "description": "Prefixes every agent with string specified here.",
+            "defaultValue": "dtl"
+        },
+        "AgentInstallLocation": {
+            "type": "string",
+            "displayName": "Agent Name Prefix",
+            "description": "Prefixes every agent with string specified here.",
+            "defaultValue": "c:\\agents"
+        },
+        "PoolName": {
+            "type": "string",
+            "displayName": "Agent Pool",
+            "description": "The agent pool this build agent should be added to."
+        },
+        "AgentCount": {
+            "type": "int",
+            "displayName": "Number of Agents",
+            "description": "The number of agents to install and add to the pool. Each agent will be named as prefix-agentname-(1..n).",
+            "defaultValue": 1
+        },
+        "Overwrite": {
+            "type": "bool",
+            "displayName": "Overwrite if agent with same name exists",
+            "defaultValue": "true",
+            "description": "If the folder with the agent name already exists, and this is true, the agent will be overwritten, otherwise installation will fail."
+        }
     },
     "runCommand": {
-      "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./run.ps1',' -Account ', parameters('Account'), ' -PersonalAccessToken ', parameters('PersonalAccessToken'), ' -AgentName ''', parameters('AgentName'), ''' -AgentNamePrefix ''', parameters('AgentNamePrefix'), ''' -PoolName ''', parameters('PoolName'), ''' -AgentCount ''', parameters('AgentCount'), '''\"')]"
+        "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./run.ps1',' -Account ', parameters('Account'), ' -PersonalAccessToken ', parameters('PersonalAccessToken'), ' -AgentName ''', parameters('AgentName'), ''' -AgentNamePrefix ''', parameters('AgentNamePrefix'), ''' -PoolName ''', parameters('PoolName'), ''' -AgentCount ''', parameters('AgentCount'), '''\"')]"
     }
-  }
+}

--- a/Artifacts/windows-azuredevops-multiple-agents/run.ps1
+++ b/Artifacts/windows-azuredevops-multiple-agents/run.ps1
@@ -1,122 +1,215 @@
 # Downloads the Azure DevOps Pipelines Agent and installs specified instances on the new machine
 # under C:\agents\ and registers with the Azure DevOps Pipelines agent pool
 
-# Enable -Verbose option
 [CmdletBinding()]
 Param
 (
-	[Parameter(Mandatory=$true)]
-	[string]$Account,
+    [Parameter()]
+    [string]$Account,
 
-	[Parameter(Mandatory=$true)]
-	[String]$PersonalAccessToken,
+    [Parameter()]
+    [String]$PersonalAccessToken,
 
-	[string]$AgentName = $env:COMPUTERNAME,
+    [Parameter()]
+    [string]$AgentName,
 
-	[string]$AgentNamePrefix= "dtl",
+    [Parameter()]
+    [string]$AgentInstallLocation,
 
-	[Parameter(Mandatory=$true)]
-	[string]$PoolName,
+    [Parameter()]
+    [string]$AgentNamePrefix,
 
-	[Parameter(Mandatory=$true)]
-	[int]$AgentCount
+    [Parameter()]
+    [string]$PoolName,
+
+    [Parameter()]
+    [int] $AgentCount,
+
+    [Parameter()]
+    [bool] $Overwrite
 )
 
-Write-Verbose "Entering powershell task" -verbose
+###################################################################################################
+#
+# PowerShell configurations
+#
 
-$currentLocation = Split-Path -parent $MyInvocation.MyCommand.Definition
-Write-Verbose "Current folder: $currentLocation" -verbose
+# NOTE: Because the $ErrorActionPreference is "Stop", this script will stop on first failure.
+#       This is necessary to ensure we capture errors inside the try-catch-finally block.
+$ErrorActionPreference = "Stop"
 
-#Create a temporary directory where to download from VSTS the agent package (vsts-agent.zip) and then launch the configuration.
-$agentTempFolderName = Join-Path $env:temp ([System.IO.Path]::GetRandomFileName())
-New-Item -ItemType Directory -Force -Path $agentTempFolderName
-Write-Verbose "Temporary Agent download folder: $agentTempFolderName" -verbose
+# Ensure we set the working directory to that of the script.
+Push-Location $PSScriptRoot
 
-$serverUrl = "https://dev.azure.com/$Account"
-Write-Verbose "Server URL: $serverUrl" -verbose
-
-$retryCount = 3
-$retries = 1
-Write-Verbose "Downloading Agent install files" -verbose
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-do
-{
-  try
-  {
-    Write-Verbose "Trying to get download URL for latest VSTS agent release..."
-    $vstsAgentUrl = "$serverUrl/_apis/distributedtask/packages/agent/win7-x64?`$top=1&api-version=3.0"
-    $basicAuth = (":{0}" -f  $PersonalAccessToken)
-    $basicAuth = [System.Text.Encoding]::UTF8.GetBytes($basicAuth)
-    $basicAuth = [System.Convert]::ToBase64String($basicAuth)
-    $headers = @{ Authorization = ("Basic {0}" -f $basicAuth) }
-    $agentList = Invoke-WebRequest -Uri $vstsAgentUrl -Headers $headers -Method Get -ContentType application/json -UseBasicParsing | ConvertFrom-Json
-    $agent = $agentList.value
-    if ($agent -is [Array])
-    {
-        $agent = $agentList.value[0]
+###################################################################################################
+#
+# Handle all errors in this script.
+#
+trap {
+    # NOTE: This trap will handle all errors. There should be no need to use a catch below in this
+    #       script, unless you want to ignore a specific error.
+    $message = $error[0].Exception.Message
+    if ($message) {
+        Write-Host -Object "ERROR: $message" -ForegroundColor Red
     }
-    $agentPackagePath = "$agentTempFolderName\agent.zip"
-
-    Invoke-WebRequest -Uri $agent.downloadUrl -Headers $headers -Method Get -OutFile  "$agentPackagePath" -UseBasicParsing | Out-Null
-
-    Write-Verbose "Downloaded agent successfully on attempt $retries" -verbose
-    break
-  }
-  catch
-  {
-    $exceptionText = ($_ | Out-String).Trim()
-    Write-Verbose "Exception occured downloading agent: $exceptionText in try number $retries" -verbose
-    $retries++
-    Start-Sleep -Seconds 30 
-  }
-} 
-while ($retries -le $retryCount)
-
-if([string]::IsNullOrWhiteSpace($AgentName)){
-	$AgentName = $env:COMPUTERNAME
+    
+    # IMPORTANT NOTE: Throwing a terminating error (using $ErrorActionPreference = "Stop") still
+    # returns exit code zero from the PowerShell script when using -File. The workaround is to
+    # NOT use -File when calling this script and leverage the try-catch-finally block and return
+    # a non-zero exit code from the catch block.
+    exit -1
 }
 
-$AgentName =("{0}-{1}" -f $AgentNamePrefix, $AgentName)
+#
+# Test the last exit code correctly.
+#
+function Test-LastExitCode {
+    param
+    (
+        [string] $Message = ''
+    )
 
-for ($i=1; $i -lt $AgentCount+1; $i++)
-{
-	$Agent = ($AgentName + "-" + $i)
+    # Whenever we execute commands such as '& somecommand' or via Invoke-Expression, we should always
+    # check the exit code, so we can decide to stop processing at that time, by throwing an exception.
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -and $exitCode -ne 0) {
+        if ($Message) {
+            if (-not $Message.EndsWith('.')) {
+                $Message += '.'
+            }
+            $Message += ' '
+        }
+        $Message += "Last command exited with error code $exitCode"
+        throw $Message
+    }
+    Write-Output "Completed with exit code: $exitCode"
+}
+###################################################################################################
+#
+# Main execution block.
+#
+try {
+    Write-Output "Entering powershell task" 
+    Write-Output "Current folder: $PSScriptRoot" 
 
-	# Construct the agent folder under the main (hardcoded) C: drive.
-	$agentInstallationPath = Join-Path "C:\agents" $Agent
+    Write-Output "Validating parameters..."
 
-	# Create the directory for this agent.
-	New-Item -ItemType Directory -Force -Path $agentInstallationPath
+    if ([string]::IsNullOrWhiteSpace($Account)) {
+        throw "Account parameter is required."
+    }
+    if ([string]::IsNullOrWhiteSpace($PersonalAccessToken)) {
+        throw "PersonalAccessToken parameter is required."
+    }
+    if ([string]::IsNullOrWhiteSpace($PoolName)) {
+        throw "PoolName parameter is required."
+    }
+    if ([string]::IsNullOrWhiteSpace($AgentName)) {
+        $AgentName = $env:COMPUTERNAME
+    }
+    if (-not [string]::IsNullOrWhiteSpace($AgentNamePrefix)) {
+        $AgentName = ("{0}-{1}" -f $AgentNamePrefix, $AgentName)
+    }
+    if ([string]::IsNullOrWhiteSpace($AgentInstallLocation)) {
+        $AgentInstallLocation = "c:\agents";
+    }
 
-	# Set the current directory to the agent dedicated one previously created.
-	Push-Location -Path $agentInstallationPath
+    #Create a temporary directory where to download from Azure DevOps the agent package (vsts-agent.zip) and then launch the configuration.
+    $agentTempFolderName = Join-Path $env:temp ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Force -Path $agentTempFolderName
+    Write-Output "Temporary Agent download folder: $agentTempFolderName" 
+
+    $serverUrl = "https://dev.azure.com/$Account"
+    Write-Output "Server URL: $serverUrl" 
+
+    $retryCount = 3
+    $retries = 1
+    Write-Output "Downloading Agent install files" 
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    do {
+        try {
+            Write-Output "Fetching download URL for latest Azure DevOps agent..."
+            $vstsAgentUrl = "$serverUrl/_apis/distributedtask/packages/agent/win7-x64?`$top=1&api-version=3.0"
+            $basicAuth = (":{0}" -f $PersonalAccessToken)
+            $basicAuth = [System.Text.Encoding]::UTF8.GetBytes($basicAuth)
+            $basicAuth = [System.Convert]::ToBase64String($basicAuth)
+            $headers = @{ Authorization = ("Basic {0}" -f $basicAuth) }
+            [array] $agentList = Invoke-WebRequest -Uri $vstsAgentUrl -Headers $headers -Method Get -ContentType application/json -UseBasicParsing | ConvertFrom-Json
+            $agent = $agentList.value[0]
+           
+            Write-Output "Agent will be downloaded to: '$agentTempFolderName'"
+
+            $agentPackagePath = "$agentTempFolderName\agent.zip"
+
+            if (Test-Path -Path $agentPackagePath) {
+                Write-Output "Directory $agentTempFolderName is not empty...Removing all contents..."
+                Remove-Item "$agentTempFolderName/*" -Force -Recurse
+            }
+
+            $downloadUrl = $agent.downloadUrl;
+
+            Write-Output "Downloading agent from: $downloadUrl"
+
+            Invoke-WebRequest -Uri $agent.downloadUrl -Headers $headers -Method Get -OutFile  "$agentPackagePath" -UseBasicParsing | Out-Null
+
+            Write-Output "Downloaded agent successfully on attempt $retries" 
+            break
+        }
+        catch {
+            $exceptionText = ($_ | Out-String).Trim()
+            Write-Output "Exception occured downloading agent: $exceptionText in try number $retries" 
+            $retries++
+            Start-Sleep -Seconds 30 
+        }
+    } 
+    while ($retries -le $retryCount)
+
+    for ($i = 1; $i -lt $AgentCount + 1; $i++) {
+        $Agent = ($AgentName + "-" + $i)
+
+
+        # Construct the agent folder under the main (hardcoded) C: drive.
+        $agentInstallationPath = Join-Path $AgentInstallLocation $Agent
+
+        #Test if the directory already exist, which probably means agent also exists
+        if (-not $Overwrite -and (Test-Path $agentInstallationPath)) {
+            Write-Output "Directory $agentInstallationPath not empty..Overwrite is set to 'false', skipping..."
+            continue;
+        }
+
+        # Create the directory for this agent.
+        New-Item -ItemType Directory -Force -Path $agentInstallationPath
+
+        # Set the current directory to the agent dedicated one previously created.
+        Push-Location -Path $agentInstallationPath
 	
-	Write-Verbose "Extracting the zip file for the agent" -verbose
-	$destShellFolder = (new-object -com shell.application).namespace("$agentInstallationPath")
-	$destShellFolder.CopyHere((new-object -com shell.application).namespace("$agentTempFolderName\agent.zip").Items(),16)
+        Write-Output "Extracting the zip file for the agent" 
+        $destShellFolder = (new-object -com shell.application).namespace("$agentInstallationPath")
+        $destShellFolder.CopyHere((new-object -com shell.application).namespace("$agentTempFolderName\agent.zip").Items(), 16)
 
-	# Removing the ZoneIdentifier from files downloaded from the internet so the plugins can be loaded
-	# Don't recurse down _work or _diag, those files are not blocked and cause the process to take much longer
-	Write-Verbose "Unblocking files" -verbose
-	Get-ChildItem -Recurse -Path $agentInstallationPath | Unblock-File | out-null
+        # Removing the ZoneIdentifier from files downloaded from the internet so the plugins can be loaded
+        # Don't recurse down _work or _diag, those files are not blocked and cause the process to take much longer
+        Write-Output "Unblocking files" 
+        Get-ChildItem -Recurse -Path $agentInstallationPath | Unblock-File | out-null
 
-	# Retrieve the path to the config.cmd file.
-	$agentConfigPath = [System.IO.Path]::Combine($agentInstallationPath, 'config.cmd')
-	Write-Verbose "Agent Location = $agentConfigPath" -Verbose
-	if (![System.IO.File]::Exists($agentConfigPath))
-	{
-		Write-Error "File not found: $agentConfigPath" -Verbose
-		return
-	}
+        # Retrieve the path to the config.cmd file.
+        $agentConfigPath = [System.IO.Path]::Combine($agentInstallationPath, 'config.cmd')
+        Write-Output "Agent Location = $agentConfigPath" 
+        if (![System.IO.File]::Exists($agentConfigPath)) {
+            throw "File not found: $agentConfigPath"
+        }
 
-	# Call the agent with the configure command and all the options (this creates the settings file) without prompting
-	# the user or blocking the cmd execution
-	Write-Verbose "Configuring agent '$($Agent)'" -Verbose		
-	.\config.cmd --unattended --url $serverUrl --auth PAT --token $PersonalAccessToken --pool $PoolName --agent $Agent --runasservice
-	
-	Write-Verbose "Agent install output: $LASTEXITCODE" -Verbose
-	
-	Pop-Location
+        # Call the agent with the configure command and all the options (this creates the settings file) without prompting
+        # the user or blocking the cmd execution
+        Write-Output "Configuring agent '$($Agent)'" 		
+        .\config.cmd --unattended --url $serverUrl --auth PAT --token $PersonalAccessToken --pool $PoolName --agent $Agent --runasservice
+        Test-LastExitCode
+
+        Pop-Location
+    }
+
+    Write-Output "Exiting InstallVSTSAgent.ps1" 
+}
+finally {
+    Pop-Location
 }
 
-Write-Verbose "Exiting InstallVSTSAgent.ps1" -Verbose

--- a/Artifacts/windows-azuredevops-multiple-agents/run.ps1
+++ b/Artifacts/windows-azuredevops-multiple-agents/run.ps1
@@ -1,0 +1,122 @@
+# Downloads the Azure DevOps Pipelines Agent and installs specified instances on the new machine
+# under C:\agents\ and registers with the Azure DevOps Pipelines agent pool
+
+# Enable -Verbose option
+[CmdletBinding()]
+Param
+(
+	[Parameter(Mandatory=$true)]
+	[string]$Account,
+
+	[Parameter(Mandatory=$true)]
+	[String]$PersonalAccessToken,
+
+	[string]$AgentName = $env:COMPUTERNAME,
+
+	[string]$AgentNamePrefix= "dtl",
+
+	[Parameter(Mandatory=$true)]
+	[string]$PoolName,
+
+	[Parameter(Mandatory=$true)]
+	[int]$AgentCount
+)
+
+Write-Verbose "Entering powershell task" -verbose
+
+$currentLocation = Split-Path -parent $MyInvocation.MyCommand.Definition
+Write-Verbose "Current folder: $currentLocation" -verbose
+
+#Create a temporary directory where to download from VSTS the agent package (vsts-agent.zip) and then launch the configuration.
+$agentTempFolderName = Join-Path $env:temp ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Force -Path $agentTempFolderName
+Write-Verbose "Temporary Agent download folder: $agentTempFolderName" -verbose
+
+$serverUrl = "https://dev.azure.com/$Account"
+Write-Verbose "Server URL: $serverUrl" -verbose
+
+$retryCount = 3
+$retries = 1
+Write-Verbose "Downloading Agent install files" -verbose
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+do
+{
+  try
+  {
+    Write-Verbose "Trying to get download URL for latest VSTS agent release..."
+    $vstsAgentUrl = "$serverUrl/_apis/distributedtask/packages/agent/win7-x64?`$top=1&api-version=3.0"
+    $basicAuth = (":{0}" -f  $PersonalAccessToken)
+    $basicAuth = [System.Text.Encoding]::UTF8.GetBytes($basicAuth)
+    $basicAuth = [System.Convert]::ToBase64String($basicAuth)
+    $headers = @{ Authorization = ("Basic {0}" -f $basicAuth) }
+    $agentList = Invoke-WebRequest -Uri $vstsAgentUrl -Headers $headers -Method Get -ContentType application/json -UseBasicParsing | ConvertFrom-Json
+    $agent = $agentList.value
+    if ($agent -is [Array])
+    {
+        $agent = $agentList.value[0]
+    }
+    $agentPackagePath = "$agentTempFolderName\agent.zip"
+
+    Invoke-WebRequest -Uri $agent.downloadUrl -Headers $headers -Method Get -OutFile  "$agentPackagePath" -UseBasicParsing | Out-Null
+
+    Write-Verbose "Downloaded agent successfully on attempt $retries" -verbose
+    break
+  }
+  catch
+  {
+    $exceptionText = ($_ | Out-String).Trim()
+    Write-Verbose "Exception occured downloading agent: $exceptionText in try number $retries" -verbose
+    $retries++
+    Start-Sleep -Seconds 30 
+  }
+} 
+while ($retries -le $retryCount)
+
+if([string]::IsNullOrWhiteSpace($AgentName)){
+	$AgentName = $env:COMPUTERNAME
+}
+
+$AgentName =("{0}-{1}" -f $AgentNamePrefix, $AgentName)
+
+for ($i=1; $i -lt $AgentCount+1; $i++)
+{
+	$Agent = ($AgentName + "-" + $i)
+
+	# Construct the agent folder under the main (hardcoded) C: drive.
+	$agentInstallationPath = Join-Path "C:\agents" $Agent
+
+	# Create the directory for this agent.
+	New-Item -ItemType Directory -Force -Path $agentInstallationPath
+
+	# Set the current directory to the agent dedicated one previously created.
+	Push-Location -Path $agentInstallationPath
+	
+	Write-Verbose "Extracting the zip file for the agent" -verbose
+	$destShellFolder = (new-object -com shell.application).namespace("$agentInstallationPath")
+	$destShellFolder.CopyHere((new-object -com shell.application).namespace("$agentTempFolderName\agent.zip").Items(),16)
+
+	# Removing the ZoneIdentifier from files downloaded from the internet so the plugins can be loaded
+	# Don't recurse down _work or _diag, those files are not blocked and cause the process to take much longer
+	Write-Verbose "Unblocking files" -verbose
+	Get-ChildItem -Recurse -Path $agentInstallationPath | Unblock-File | out-null
+
+	# Retrieve the path to the config.cmd file.
+	$agentConfigPath = [System.IO.Path]::Combine($agentInstallationPath, 'config.cmd')
+	Write-Verbose "Agent Location = $agentConfigPath" -Verbose
+	if (![System.IO.File]::Exists($agentConfigPath))
+	{
+		Write-Error "File not found: $agentConfigPath" -Verbose
+		return
+	}
+
+	# Call the agent with the configure command and all the options (this creates the settings file) without prompting
+	# the user or blocking the cmd execution
+	Write-Verbose "Configuring agent '$($Agent)'" -Verbose		
+	.\config.cmd --unattended --url $serverUrl --auth PAT --token $PersonalAccessToken --pool $PoolName --agent $Agent --runasservice
+	
+	Write-Verbose "Agent install output: $LASTEXITCODE" -Verbose
+	
+	Pop-Location
+}
+
+Write-Verbose "Exiting InstallVSTSAgent.ps1" -Verbose


### PR DESCRIPTION
Downloads latest Azure Pipelines agent for the account, and installs the specified number instances of the agents inside one DevTestLabs VM. Registers the agent with the Azure DevOps account, and adds agents to the specified agent pool. Note - If the specified agent folder already exists it will be overwritten.

Useful if you would like to install multiple agents inside a single VM.

![image](https://user-images.githubusercontent.com/2685029/46400958-942b0500-c6f3-11e8-84f0-0303c657f66e.png)
