### PR TITLE
fix missing argument for adding tags to Deployment Group (#439)

### DIFF
--- a/Artifacts/windows-deploymentgroup/InstallAndConfigureDeploymentGroupAgent.ps1
+++ b/Artifacts/windows-deploymentgroup/InstallAndConfigureDeploymentGroupAgent.ps1
@@ -249,7 +249,7 @@ function Configure-DeploymentGroupAgent
     }
     if(-not [string]::IsNullOrWhiteSpace($deploymentAgentTags))
     {
-        $agentConfigArgs += "--deploymentgrouptags", $deploymentAgentTags
+        $agentConfigArgs += "--adddeploymentgrouptags", "--deploymentgrouptags", $deploymentAgentTags
     }
 
     & .\config.cmd $agentConfigArgs


### PR DESCRIPTION
Fixes #439 
Tested the script manually (i.e. not via an artifact deployment). Tags are now added correctly.