### PR TITLE
Update DTL artifact "windows-vsts-download-and-run-script"

### DIFF
--- a/Artifacts/windows-vsts-download-and-run-script/DownloadVstsDropAndExecuteScript.ps1
+++ b/Artifacts/windows-vsts-download-and-run-script/DownloadVstsDropAndExecuteScript.ps1
@@ -72,6 +72,11 @@ function Get-BuildArtifacts
     # Process all artifacts found.
     foreach ($artifact in $artifacts)
     {
+        if ($artifact.resource.type -notlike "Container") {
+            Write-Host "Skip download of artifact $($artifact.name) as it is not of type 'Container'"
+            continue
+        }
+        
         $artifactName = "$($artifact.name)"
         $artifactZip = "$artifactName.zip"
         Write-Host "Preparing to download artifact $artifactName to file $artifactZip"


### PR DESCRIPTION
## Purpose

Skip download of DevOps artifact (in the build pipeline) if it is not of type Container

## Reason

REST call done in function Get-BuildArtifacts may return artifacts that are not of type "Container" (for example, of type "GitRef"). Such artifacts don't have a downloadUrl property, which causes the script to throw error "Unable to get the download URL for artifact $artifactName.".
To prevent this I added a test to download the artifact only if it is  of type "Container"

## Example of a JSON reply from DevOps, with both type of artifacts

```json
{
  "count": 2,
  "value": [
    {
      "id": 440,
      "name": "drop",
      "resource": {
        "type": "Container",
        "data": "#/2992449/drop",
        "properties": {
          "localpath": "D:\\a\\1\\a"
        },
        "url": "https://dev.azure.com/YvanDev/8af08941-9998-40ec-9511-eef1a2f107d4/_apis/build/builds/660/artifacts?artifactName=drop&api-version=2.0",
        "downloadUrl": "https://dev.azure.com/YvanDev/8af08941-9998-40ec-9511-eef1a2f107d4/_apis/build/builds/660/artifacts?artifactName=drop&api-version=2.0&%24format=zip"
      }
    },
    {
      "id": 442,
      "name": "build.SourceLabel",
      "resource": {
        "_links": {
          "web": {
            "href": "https://dev.azure.com/YvanDev/8af08941-9998-40ec-9511-eef1a2f107d4/_build/artifact?type=GitRef&resource={\"ref\":\"14.0.20190307.660\",\"commit\":\"1493125d256ec448f1a84a5c852d476822f7d48e\",\"sha\":\"a1e54add3928e2f3205add7e66cc19fc6bdc7bfd\"}"
          }
        },
        "type": "GitRef",
        "data": "{\"ref\":\"14.0.20190307.660\",\"commit\":\"1493125d256ec448f1a84a5c852d476822f7d48e\",\"sha\":\"a1e54add3928e2f3205add7e66cc19fc6bdc7bfd\"}",
        "url": "https://dev.azure.com/YvanDev/8af08941-9998-40ec-9511-eef1a2f107d4/_apis/build/builds/660/artifacts?artifactName=build.SourceLabel&api-version=2.0"
      }
    }
  ]
}
```