### PR TITLE
Fixing Service Fabric SDK and Tools hang

### DIFF
--- a/Artifacts/windows-ServiceFabricSDK/InstallServiceFabricSDKAndTools.ps1
+++ b/Artifacts/windows-ServiceFabricSDK/InstallServiceFabricSDKAndTools.ps1
@@ -76,6 +76,9 @@ function Get-VSSetupInstances
             Write-Host "Updating NuGet provider to a version higher than 2.8.5.201."
             Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 
+            Write-Host "Installing PowerShellGet module."            
+            Install-Module -Name PowerShellGet -Force
+
             Write-Host "Installing VSSetup module."
             Install-Module -Name VSSetup -Force
         }

--- a/Artifacts/windows-ServiceFabricSDK/InstallServiceFabricSDKAndTools.ps1
+++ b/Artifacts/windows-ServiceFabricSDK/InstallServiceFabricSDKAndTools.ps1
@@ -73,9 +73,6 @@ function Get-VSSetupInstances
     $null = @(
         if (-not (Get-Module -ListAvailable -Name VSSetup))
         {
-            Write-Host "Installing PowerShellGet module."            
-            Install-Module -Name PowerShellGet -Force
-
             Write-Host "Updating NuGet provider to a version higher than 2.8.5.201."
             Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 
@@ -89,6 +86,20 @@ function Get-VSSetupInstances
 
     # Get VS installation information.
     return Get-VSSetupInstance
+}
+
+function Test-PowerShellVersion
+{
+    [CmdletBinding()]
+    param(
+        [double] $Version
+    )
+
+    $currentVersion = [double] "$($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor)"
+    if ($currentVersion -lt $Version)
+    {
+        throw "The current version of PowerShell is $currentVersion. Prior to running this artifact, ensure you have PowerShell version $Version or higher installed."
+    }
 }
 
 function Test-VSVersion
@@ -374,6 +385,8 @@ try
     Write-Host "Starting installation of Service Fabric SDK and Tools for $VSVersion."
 
     # For this process, we want to be able to execute downloaded scripts.
+    Write-Host 'Configuring PowerShell session.'
+    Test-PowerShellVersion -Version 5.1
     Set-ExecutionPolicy Bypass -Scope Process -Force | Out-Null
 
     # Change the "Local AppData" path to a location where the process can write, or the relevant

--- a/Artifacts/windows-ServiceFabricSDK/README.md
+++ b/Artifacts/windows-ServiceFabricSDK/README.md
@@ -9,6 +9,7 @@ For Visual Studio 2017, the core 'Microsoft Azure Service Fabric SDK' will be in
 ## Prerequisites
 
 - Visual Studio 2015 or Visual Studio 2017 must be installed on the VM.  See [Visual Studio Downloads](https://www.visualstudio.com/downloads/) for details how to install Visual Studio.
+- PowerShell version 5.1 or newer must be installed on the VM.
 
 ## Parameters
 

--- a/Artifacts/windows-ServiceFabricSDK/artifactfile.json
+++ b/Artifacts/windows-ServiceFabricSDK/artifactfile.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
   "title": "Service Fabric SDK and Tools",
   "publisher": "Microsoft",
-  "description": "Installs the latest available version of the Microsoft Azure Service Fabric SDK using WebPI. Service Fabric SDK Tools for Visual Studio are also installed. Microsoft Visual Studio 2015 or Microsoft Visual Studio 2017 must already be installed before using this artifact.",
+  "description": "Installs the latest available version of the Microsoft Azure Service Fabric SDK using WebPI. Service Fabric SDK Tools for Visual Studio are also installed. Microsoft Visual Studio 2015 or Microsoft Visual Studio 2017 must already be installed before using this artifact. PowerShell version 5.1 or newer must also be installed.",
   "tags": [
     "Microsoft",
     "Windows",

--- a/Artifacts/windows-deploymentgroup/Artifactfile.json
+++ b/Artifacts/windows-deploymentgroup/Artifactfile.json
@@ -3,7 +3,7 @@
     "title": "Azure Pipelines Deployment Group Agent",
     "description": "Downloads the latest deployment agent from Azure DevOps and configures it against the specified deployment group.",
     "publisher": "Microsoft",
-    "iconUri": "https://www.visualstudio.com/favicon.ico",
+    "iconUri": "https://cdn.vsassets.io/content/icons/favicon.ico",
     "targetOsType": "Windows",
     "parameters": {
         "accountUrl": {


### PR DESCRIPTION
* Added check to ensure PowerShell version 5.1 or newer is installed.
* Added statement to indicate the version of PowerShell that's required for this artifact to work correctly.