### PR TITLE
Changing method used to allocate swap files

### DIFF
--- a/Artifacts/linux-swapfile/Artifactfile.json
+++ b/Artifacts/linux-swapfile/Artifactfile.json
@@ -12,9 +12,9 @@
         "size": {
             "type": "string",
             "displayName": "Size",
-            "description": "The size of the swap file. Defaults to bytes, or use the suffixes k, m, or g which correspond to KiB, MiB, and GiB respectively. For example: 5g = 5GiB, 100m = 100MiB.",
+            "description": "The size of the swap file. Defaults to bytes, or use the suffixes K, M, or G which correspond to KiB, MiB, and GiB respectively. For example: 5G = 5 GiB, 100M = 100 MiB.",
             "allowEmpty": false,
-            "defaultValue": "1g"
+            "defaultValue": "1G"
         }
     },
     "runCommand": {

--- a/Artifacts/linux-swapfile/linux_swapfile.sh
+++ b/Artifacts/linux-swapfile/linux_swapfile.sh
@@ -9,13 +9,20 @@
 
 set -e
 
-# Generate a file name based on the current date to avoid naming conflicts
+# Generate a file name based on the current date to avoid naming conflicts.
 SIZE="$1"
 FILENAME="$(date +%s | sha256sum | base64 | head -c 32)"
 FILEPATH="/mnt/$FILENAME"
 
-fallocate -l $SIZE $FILEPATH
+# In previous versions of this script, we used fallocate. But that started failing on newer
+# OS versions. So, although fallocate can be faster, we are changing to use dd instead. The
+# nomenclature is slightly different. So, we need to make sure the user is aware of it.
+# For example, to create a 1 GB swap file, the caller will need to specify 1073741824 (bytes)
+# or 1G. Note that case here is important.
+dd if=/dev/zero of=$FILEPATH bs=$SIZE count=1
+
 chmod 600 $FILEPATH
 mkswap $FILEPATH
 swapon $FILEPATH
+
 echo “$FILEPATH  none  swap  sw  0 0” >> /etc/fstab


### PR DESCRIPTION
In previous versions of this script, we used `fallocate`. But that started failing on newer OS versions. So, although `fallocate` can be faster, we are changing to use `dd` instead. The nomenclature is slightly different. So, we need to make sure the user is aware of it. For example, to create a 1 GB swap file, the caller will need to specify 1073741824 (bytes) or 1G. Note that case here is important.