### PR TITLE
Removing package update logic

### DIFF
--- a/Artifacts/linux-java/linux_install_jdk.sh
+++ b/Artifacts/linux-java/linux_install_jdk.sh
@@ -20,16 +20,11 @@ set -e
 if [ -n "$isApt" ] ; then
     echo "Using APT package manager"
 
-    sudo apt-get -y update
-    
     sudo apt-get -y install default-jdk
     exit 0
 elif [ -n "$isYum" ] ; then
     echo "Using YUM package manager"
 
-    yum -y update
-    yum clean all
-    
     yum install -y java-1.8.0-openjdk
     exit 0
 fi


### PR DESCRIPTION
Removing the package update logic from this artifact, as it causes the artifact to intermittently fail due to a timeout. The call is not really needed. If there is a dependency that is required, we can then re-evaluate the logic and update accordingly.