### PR TITLE
Change Delete Environment to log message when environment not found

### DIFF
--- a/tasks/AzureDtlDeleteEnvironment/task-funcs.ps1
+++ b/tasks/AzureDtlDeleteEnvironment/task-funcs.ps1
@@ -57,6 +57,6 @@ function Remove-DevTestLabEnvironment {
         }
     }   
     else {
-        throw "Could not find environment '$environmentId' in lab '$($lab.Name)' owned by user '$usr'."
+        Write-Host "Could not find environment '$environmentId' in lab '$($lab.Name)' owned by user '$usr'."
     } 
 }

--- a/tasks/AzureDtlDeleteEnvironment/task.json
+++ b/tasks/AzureDtlDeleteEnvironment/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [
         "azureps"

--- a/tasks/vss-extension.json
+++ b/tasks/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "tasks",
-    "version": "1.0.52",
+    "version": "1.0.53",
     "name": "Azure DevTest Labs Tasks",
     "publisher": "ms-azuredevtestlabs",
     "description": "Collection of build/release tasks to interact with Azure DevTest Labs.",


### PR DESCRIPTION
Throwing an error on delete environment when the environment to delete doesn't exist is an annoyance.  Changing it to log a message.