### PR TITLE
Update to a more reliable way to get VM Status

### DIFF
--- a/samples/DevTestLabs/Modules/Library/Az.DevTestLabs2.psm1
+++ b/samples/DevTestLabs/Modules/Library/Az.DevTestLabs2.psm1
@@ -12,7 +12,7 @@ Set-StrictMode -Version Latest
 # If you have the AzureRm module, then everything works fine
 # If you have the Az module, we need to enable the AzureRmAliases
 
-$azureRm  = Get-Module -Name "AzureRM.Profile" -ListAvailable
+$azureRm  = Get-Module -Name "AzureRM" -ListAvailable | Sort-Object Version.Major -Descending | Select-Object -First 1
 $az       = Get-Module -Name "Az.Accounts" -ListAvailable
 $justAz   = $az -and (-not $azureRm)
 
@@ -21,10 +21,15 @@ if($azureRm -and $az) {
 }
 
 if($azureRm) {
-  # This is not defaulted in older versions of AzureRM
-  Enable-AzureRmContextAutosave -Scope CurrentUser -erroraction silentlycontinue
-  Write-Warning "You are using the deprecated AzureRM module. For more info, read https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az"
+  if ($azureRm.Version.Major -lt 6) {
+    Write-Error "This module does not work correctly with version 5 or lower of AzureRM, please upgrade to a newer version of Azure PowerShell in order to use this module."
+  } else {
+    # This is not defaulted in older versions of AzureRM
+    Enable-AzureRmContextAutosave -Scope CurrentUser -erroraction silentlycontinue
+    Write-Warning "You are using the deprecated AzureRM module. For more info, read https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az"
+  }
 }
+
 if($justAz) {
   Enable-AzureRmAlias -Scope Local -Verbose:$false
 }

--- a/samples/DevTestLabs/Modules/Library/Tests/VirtualMachine/ExtendedStatus.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/VirtualMachine/ExtendedStatus.tests.ps1
@@ -1,0 +1,48 @@
+Import-Module $PSScriptRoot\..\..\Az.DevTestLabs2.psm1
+
+$lab = @(
+    [pscustomobject]@{Name='DTL-Library-Test1'; ResourceGroupName='DTL-Library-Test1rg'; Location='westus'}
+)
+
+$vm = @(
+    [pscustomobject]@{VmName='WinVm1Status'; Size='Standard_A4_v2'; UserName='bob'; Password='aPassword341341'; OsType='Windows'; Sku='2012-R2-Datacenter'; Publisher='MicrosoftWindowsServer'; Offer='WindowsServer'}
+)
+
+Describe  'Virtual Machine Tests' {
+
+    Context 'Properties' {
+
+        It 'Extended status for Virtual Machine' {
+
+            # Create the resource groups, using a little property projection
+            $lab | Select-Object -Property @{N='Name'; E={$_.ResourceGroupName}}, Location | New-AzResourceGroup -Force | Out-Null
+
+            # Create the lab
+            $createdLab = $lab | New-AzDtlLab
+
+            # Create VM in a lab
+            $createdVM = $vm| Select-Object -Property @{N='Name'; E={$createdLab.Name}}, @{N='ResourceGroupName'; E={$createdLab.ResourceGroupName}}, VmName,Size,Claimable,Username,Password,OsType,Sku,Publisher,Offer | New-AzDtlVm
+
+            # Stop the VM
+            Stop-AzDtlVm -Vm $createdVM
+
+            # Status fields of the VMs should be 'Stopped' for a VM stopped via DTL
+            (Get-AzDtlVmStatus -Vm $createdVM -ExtendedStatus) | Should -Be "Stopped" -Because "$($createdVM.Name) should be stopped"
+
+            # Start the VM
+            Start-AzDtlVm -Vm $createdVM
+
+            # Status field of the VMs should be'Running' for a VM started via DTL
+            (Get-AzDtlVmStatus -Vm $createdVM -ExtendedStatus) | Should -Be "Running" -Because "$($createdVM.Name) should be running"
+        }
+
+        It 'Cleanup of resources' {
+
+            # Remove Labs using the Lab Object returned from 'get' commandlet
+            $lab | Get-AzDtlLab | Remove-AzDtlLab
+
+            # Clean up the resource groups since we don't need them
+            $lab | Select-Object -Property @{N='Name'; E={$_.ResourceGroupName}}, Location | Remove-AzResourceGroup -Force | Out-Null
+        }
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-devtestlab/issues/495

Updating the code for getting the status of a VM to jump to the underlying Compute VM for the 'real' status.  In most cases, this is 1 additional call to Azure (Get-AzureRmVm -Status)