### PR TITLE
Fix for Azure Pipelines hosted agent which has Az 1.0.0 and AzureRm 2.1.0

### DIFF
--- a/samples/DevTestLabs/Modules/Library/Az.DevTestLabs2.psm1
+++ b/samples/DevTestLabs/Modules/Library/Az.DevTestLabs2.psm1
@@ -31,7 +31,7 @@ if($justAzureRm) {
   }
 }
 
-if($justAz) {
+if($justAz -or ($az -and ($azureRm.Version.Major -lt 6)) {
   Enable-AzureRmAlias -Scope Local -Verbose:$false
 }
 

--- a/samples/DevTestLabs/Modules/Library/Az.DevTestLabs2.psm1
+++ b/samples/DevTestLabs/Modules/Library/Az.DevTestLabs2.psm1
@@ -15,12 +15,13 @@ Set-StrictMode -Version Latest
 $azureRm  = Get-Module -Name "AzureRM" -ListAvailable | Sort-Object Version.Major -Descending | Select-Object -First 1
 $az       = Get-Module -Name "Az.Accounts" -ListAvailable
 $justAz   = $az -and (-not $azureRm)
+$justAzureRm = $azureRm -and (-not $az)
 
 if($azureRm -and $az) {
   Write-Warning "You have both Az and AzureRm module installed. That is not officially supported. For more read here: https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az"
 }
 
-if($azureRm) {
+if($justAzureRm) {
   if ($azureRm.Version.Major -lt 6) {
     Write-Error "This module does not work correctly with version 5 or lower of AzureRM, please upgrade to a newer version of Azure PowerShell in order to use this module."
   } else {


### PR DESCRIPTION
Azure Pipelines has a somewhat weird combination using Azure Powershell v4.0 version of the task.  It has the latest (Az 1.0.0) but a REALLY old version of AzureRM (2.x).  We weren't catching this case in the library, added code to handle it.