### PR TITLE
Added Author in CreateImageFromVHD.json

### DIFF
--- a/samples/DevTestLabs/Scripts/ImageFactory/Scripts/CreateImageFromVHD.json
+++ b/samples/DevTestLabs/Scripts/ImageFactory/Scripts/CreateImageFromVHD.json
@@ -1,78 +1,92 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "existingLabName": {
-            "type": "String",
-            "metadata": {
-                "description": "Name of an existing lab where the custom image will be created or updated."
-            }
-        },
-        "existingVhdUri": {
-            "type": "String",
-            "metadata": {
-                "description": "URI of an existing VHD from which the custom image will be created or updated."
-            }
-        },
-        "imageOsType": {
-            "defaultValue": "windows",
-            "type": "String",
-            "metadata": {
-                "description": "Specifies the OS type of the VHD. Currently 'Windows' and 'Linux' are the only supported values."
-            }
-        },
-        "isVhdSysPrepped": {
-            "defaultValue": true,
-            "type": "Bool",
-            "metadata": {
-                "description": "If the existing VHD is a Windows VHD, then specifies whether the VHD is sysprepped (Note: If the existing VHD is NOT a Windows VHD, then please specify 'false')."
-            }
-        },
-        "imageName": {
-            "type": "String",
-            "metadata": {
-                "description": "Name of the custom image being created or updated."
-            }
-        },
-        "imageDescription": {
-            "defaultValue": "",
-            "type": "String",
-            "metadata": {
-                "description": "Details about the custom image being created or updated."
-            }
-        },
-        "imageAuthor": {
-            "defaultValue": "",
-            "type": "String",
-            "metadata": {
-                "description": "Name of the author who created the custom image."
-            }
-        }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "existingLabName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of an existing lab where the custom image will be created or updated."
+      }
     },
-    "variables": {
-        "resourceName": "[concat(parameters('existingLabName'), '/', parameters('imageName'))]",
-        "resourceType": "Microsoft.DevTestLab/labs/customimages"
+    "existingVhdUri": {
+      "type": "string",
+      "metadata": {
+        "description": "URI of an existing VHD from which the custom image will be created or updated."
+      }
     },
-    "resources": [
-        {
-            "type": "Microsoft.DevTestLab/labs/customimages",
-            "apiVersion": "2018-10-15-preview",
-            "name": "[variables('resourceName')]",
-            "properties": {
-                "vhd": {
-                    "imageName": "[parameters('existingVhdUri')]",
-                    "sysPrep": "[parameters('isVhdSysPrepped')]",
-                    "osType": "[parameters('imageOsType')]"
-                },
-                "description": "[parameters('imageDescription')]",
-                "author": "[parameters('imageAuthor')]"
-            }
-        }
-    ],
-    "outputs": {
-        "customImageId": {
-            "type": "String",
-            "value": "[resourceId(variables('resourceType'), parameters('existingLabName'), parameters('imageName'))]"
-        }
+    "imageOsType": {
+      "type": "string",
+      "defaultValue": "Windows",
+      "allowedValues": [
+        "Linux",
+        "Windows"
+      ],
+      "metadata": {
+        "description": "Specifies the OS type of the VHD. Currently 'Windows' and 'Linux' are the only supported values."
+      }
+    },
+    "isVhdSysPrepped": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "If the existing VHD is a Windows VHD, then specifies whether the VHD is sysprepped (Note: If the existing VHD is NOT a Windows VHD, then please specify 'false')."
+      }
+    },
+    "imageName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the custom image being created or updated."
+      }
+    },
+    "imagePath": {
+      "type": "string",
+      "metadata": {
+        "description": "The path to the golden image template"
+      }
+    },
+    "imageDescription": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Details about the custom image being created or updated."
+      }
+    },
+    "imageAuthor": {
+      "defaultValue": "",
+      "type": "String",
+      "metadata": {
+         "description": "Name of the author who created the custom image."
+      }
     }
+  },
+  "variables": {
+    "resourceName": "[concat(parameters('existingLabName'), '/', parameters('imageName'))]",
+    "resourceType": "Microsoft.DevTestLab/labs/customimages"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-05-15",
+      "name": "[variables('resourceName')]",
+      "type": "Microsoft.DevTestLab/labs/customimages",
+      "tags": {
+        "ImagePath": "[parameters('imagePath')]"
+      },
+      "properties": {
+        "author": "Image Factory",
+        "vhd": {
+          "imageName": "[parameters('existingVhdUri')]",
+          "sysPrep": "[parameters('isVhdSysPrepped')]",
+          "osType": "[parameters('imageOsType')]"
+        },
+        "description": "[parameters('imageDescription')]",
+        "author": "[parameters('imageAuthor')]"
+      }
+    }
+  ],
+  "outputs": {
+    "customImageId": {
+      "type": "string",
+      "value": "[resourceId(variables('resourceType'), parameters('existingLabName'), parameters('imageName'))]"
+    }
+  }
 }

--- a/samples/DevTestLabs/Scripts/ImageFactory/Scripts/CreateImageFromVHD.json
+++ b/samples/DevTestLabs/Scripts/ImageFactory/Scripts/CreateImageFromVHD.json
@@ -1,84 +1,78 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "parameters": {
-    "existingLabName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of an existing lab where the custom image will be created or updated."
-      }
-    },
-    "existingVhdUri": {
-      "type": "string",
-      "metadata": {
-        "description": "URI of an existing VHD from which the custom image will be created or updated."
-      }
-    },
-    "imageOsType": {
-      "type": "string",
-      "defaultValue": "Windows",
-      "allowedValues": [
-        "Linux",
-        "Windows"
-      ],
-      "metadata": {
-        "description": "Specifies the OS type of the VHD. Currently 'Windows' and 'Linux' are the only supported values."
-      }
-    },
-    "isVhdSysPrepped": {
-      "type": "bool",
-      "defaultValue": true,
-      "metadata": {
-        "description": "If the existing VHD is a Windows VHD, then specifies whether the VHD is sysprepped (Note: If the existing VHD is NOT a Windows VHD, then please specify 'false')."
-      }
-    },
-    "imageName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the custom image being created or updated."
-      }
-    },
-    "imagePath": {
-      "type": "string",
-      "metadata": {
-        "description": "The path to the golden image template"
-      }
-    },
-    "imageDescription": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Details about the custom image being created or updated."
-      }
-    }
-  },
-  "variables": {
-    "resourceName": "[concat(parameters('existingLabName'), '/', parameters('imageName'))]",
-    "resourceType": "Microsoft.DevTestLab/labs/customimages"
-  },
-  "resources": [
-    {
-      "apiVersion": "2016-05-15",
-      "name": "[variables('resourceName')]",
-      "type": "Microsoft.DevTestLab/labs/customimages",
-      "tags": {
-        "ImagePath": "[parameters('imagePath')]"
-      },
-      "properties": {
-        "author": "Image Factory",
-        "vhd": {
-          "imageName": "[parameters('existingVhdUri')]",
-          "sysPrep": "[parameters('isVhdSysPrepped')]",
-          "osType": "[parameters('imageOsType')]"
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "existingLabName": {
+            "type": "String",
+            "metadata": {
+                "description": "Name of an existing lab where the custom image will be created or updated."
+            }
         },
-        "description": "[parameters('imageDescription')]"
-      }
+        "existingVhdUri": {
+            "type": "String",
+            "metadata": {
+                "description": "URI of an existing VHD from which the custom image will be created or updated."
+            }
+        },
+        "imageOsType": {
+            "defaultValue": "windows",
+            "type": "String",
+            "metadata": {
+                "description": "Specifies the OS type of the VHD. Currently 'Windows' and 'Linux' are the only supported values."
+            }
+        },
+        "isVhdSysPrepped": {
+            "defaultValue": true,
+            "type": "Bool",
+            "metadata": {
+                "description": "If the existing VHD is a Windows VHD, then specifies whether the VHD is sysprepped (Note: If the existing VHD is NOT a Windows VHD, then please specify 'false')."
+            }
+        },
+        "imageName": {
+            "type": "String",
+            "metadata": {
+                "description": "Name of the custom image being created or updated."
+            }
+        },
+        "imageDescription": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "Details about the custom image being created or updated."
+            }
+        },
+        "imageAuthor": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "Name of the author who created the custom image."
+            }
+        }
+    },
+    "variables": {
+        "resourceName": "[concat(parameters('existingLabName'), '/', parameters('imageName'))]",
+        "resourceType": "Microsoft.DevTestLab/labs/customimages"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.DevTestLab/labs/customimages",
+            "apiVersion": "2018-10-15-preview",
+            "name": "[variables('resourceName')]",
+            "properties": {
+                "vhd": {
+                    "imageName": "[parameters('existingVhdUri')]",
+                    "sysPrep": "[parameters('isVhdSysPrepped')]",
+                    "osType": "[parameters('imageOsType')]"
+                },
+                "description": "[parameters('imageDescription')]",
+                "author": "[parameters('imageAuthor')]"
+            }
+        }
+    ],
+    "outputs": {
+        "customImageId": {
+            "type": "String",
+            "value": "[resourceId(variables('resourceType'), parameters('existingLabName'), parameters('imageName'))]"
+        }
     }
-  ],
-  "outputs": {
-    "customImageId": {
-      "type": "string",
-      "value": "[resourceId(variables('resourceType'), parameters('existingLabName'), parameters('imageName'))]"
-    }
-  }
 }


### PR DESCRIPTION
Added the Author as parameter and the value in the template file as there is currently a bug in the azure portal and the author can be useful when working with multiple image factories or people using the image factory.

For the bug see the forum: https://social.msdn.microsoft.com/Forums/en-US/8d01bee1-4d0c-4775-b970-fff7196f3ed8/custom-images-without-author-wont-show-description-while-creating-vm-in-devtest-lab?forum=AzureDevTestLabs#8d01bee1-4d0c-4775-b970-fff7196f3ed8