### PR TITLE
Add artifact to configure Linux vsts build agent

### DIFF
--- a/Artifacts/linux-vsts-build-agent/Artifactfile.json
+++ b/Artifacts/linux-vsts-build-agent/Artifactfile.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
+  "title": "Azure Pipelines Agent for Linux",
+  "publisher": "Microsoft",
+  "description": "Downloads and installs the Azure Pipelines agent, registers with the specified Azure DevOps Services account, and adds the VM to the specified agent pool.",
+  "tags": [
+    "VSTS",
+    "Build",
+    "CI",
+    "Linux"
+  ],
+  "iconUri": "https://cdn.vsassets.io/content/icons/favicon.ico",
+  "targetOsType": "Linux",
+  "parameters": {
+    "adoAccount": {
+      "type": "string",
+      "displayName": "Azure DevOps Organization Name",
+      "description": "The name of the Azure DevOps organization to add the agent to. This is the value in your Azure DevOps URL: e.g. 'myorg' in https://dev.azure.com/myorg."
+    },
+    "adoPat": {
+      "type": "securestring",
+      "displayName": "Azure DevOps Personal Access Token",
+      "description": "A personal access token with permissions to add agents. It will only be used to register the agent. See https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-linux?view=azure-devops for more information"
+    },
+    "adoPool": {
+      "type": "string",
+      "displayName": "Agent Pool",
+      "description": "The agent pool this build agent should be added to."
+    },
+    "agentPath": {
+      "type": "string",
+      "displayName": "Agent Path",
+      "description": "Path where agent is stored. Any storage space used by the agent is in a subdirectory of the agent path."
+    },
+    "agentName": {
+        "type": "string",
+        "displayName": "Agent Name",
+        "description": "A unique name identifying this agent. If not specified, it defaults to the hostname of the machine running the agent",
+        "allowEmpty": true
+    }
+  },
+  "runCommand": {
+    "commandToExecute": "[concat('python3 ', './agent-install.py', ' --agent_path ''', parameters('agentPath'), ''' --ado_pat ''', parameters('adoPat'), ''' --ado_account ''', parameters('adoAccount'), ''' --ado_pool ''', parameters('adoPool'), ''' --agent_name ''', parameters('agentName'), '''')]"
+  }
+}

--- a/Artifacts/linux-vsts-build-agent/agent-install.py
+++ b/Artifacts/linux-vsts-build-agent/agent-install.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python3
+
+from argparse import ArgumentParser
+from socket import gethostname
+from os import path, makedirs, environ
+from sys import argv
+from tempfile import TemporaryDirectory
+from subprocess import run, PIPE, STDOUT
+from requests import get
+from json import loads
+
+def parse_args(args):
+    parser = ArgumentParser()
+    parser.add_argument("-p", "--agent_path", required = True)
+    parser.add_argument("-t", "--ado_pat", required = True)
+    parser.add_argument("-a", "--ado_account", required = True)
+    parser.add_argument("-l", "--ado_pool", required = True)
+    parser.add_argument("-n", "--agent_name", required = False)
+    result = parser.parse_args(args)
+    if not result.agent_name:
+        result.agent_name = gethostname()
+    return result
+
+def combine_command(command):
+    return " ".join(command)
+
+def failed(results):
+    return results.returncode != 0
+
+def execute_command_silent(command, cwd = None, env = None):
+    results = run(command, stdout = PIPE, stderr = STDOUT, cwd = cwd, env = env)
+    if failed(results):
+        raise Exception(f"{combine_command(command)} failed. stdout={results.stdout} stderr={results.stderr}")
+    return results
+
+def execute_command(command, cwd = None, env = None):
+    print (combine_command(command))
+    return execute_command_silent(command, cwd = cwd, env = env)
+
+def ensure_directory(dir):
+    if not path.exists(dir):
+        makedirs(dir)
+
+def get_package_url(args):
+    url = f"https://{args.ado_account}.visualstudio.com/_apis/distributedtask/packages/agent/linux-x64?$top=1&api-version=3.0"
+    print(f"fetching {url} to determine agent package url")
+    response = get(url, auth=("AzureDevTestLabs", args.ado_pat))
+    as_json = loads(response.text)
+    return as_json["value"][0]["downloadUrl"]
+
+def download_and_extract_agent_package(args):
+    with TemporaryDirectory() as temp_dir:
+        execute_command([
+            "wget",
+            "--secure-protocol", "TLSv1_2",
+            "-O", "agent.tgz",
+            get_package_url(args)
+        ], cwd = str(temp_dir))
+        execute_command([
+            "tar",
+            "zxvf",
+            f"{temp_dir}/agent.tgz"
+        ], cwd = args.agent_path)
+
+def install_dependencies(agent_path):
+    execute_command([
+        "sudo",
+        "bin/installdependencies.sh"
+    ], cwd = agent_path)
+
+def configure_agent(args):
+    d = dict(environ)
+    d["AGENT_ALLOW_RUNASROOT"] = str("1")
+    execute_command([
+        "./config.sh",
+        "--unattended",
+        "--url", f"https://{args.ado_account}.visualstudio.com",
+        "--auth", "pat",
+        "--pool", args.ado_pool,
+        "--agent", args.agent_name,
+        "--work",  f"{args.agent_path}/_work",
+        "--token", args.ado_pat
+    ], cwd = args.agent_path, env = d)
+
+def install_and_start(agent_path):
+    execute_command([
+        "sudo",
+        "./svc.sh",
+        "install"
+    ], cwd = agent_path)
+    execute_command([
+        "sudo",
+        "./svc.sh",
+        "start"
+    ], cwd = agent_path)
+
+def main():
+    args = parse_args(argv[1:])
+    ensure_directory(args.agent_path)
+    download_and_extract_agent_package(args)
+    install_dependencies(args.agent_path)
+    configure_agent(args)
+    install_and_start(args.agent_path)
+    return 0
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
This artifact is inspired by the similar one made for Windows.
It allows a linux vm to be set up as a build agent for Azure DevOps.
Steps:
1. Determine the latest agent package to download by making a REST query
2. Download and extract the latest agent package to the vm
3. Using the parameters provided, run the setup commands for the agent as documented here: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-linux?view=azure-devops
