### PR TITLE
Az.LabServices: making test truly multi-thread safe and add a cleanup script to run after build

### DIFF
--- a/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
+++ b/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
@@ -899,7 +899,7 @@ function Get-AzLabAccountSharedImage {
         try {
             foreach ($la in $LabAccount) {
                 $uri = (ConvertToUri -resource $la) + "/SharedImages"
-                InvokeRest -Uri $uri -Method 'Get' | Where-Object { $_.properties.EnableState -eq 'Enabled' }
+                return InvokeRest -Uri $uri -Method 'Get' | Where-Object { $_.properties.EnableState -eq 'Enabled' }
             }
         }
         catch {
@@ -1352,8 +1352,7 @@ function New-AzLabSchedule {
 
                 Write-Verbose $body
 
-                InvokeRest -Uri $uri -Method 'Put' -Body $body | Out-Null
-                return $l
+                return InvokeRest -Uri $uri -Method 'Put' -Body $body
             }
         }
         catch {

--- a/samples/ClassroomLabs/Modules/Library/Scenarios/AllFeatures.ps1
+++ b/samples/ClassroomLabs/Modules/Library/Scenarios/AllFeatures.ps1
@@ -27,10 +27,9 @@ $vm = $lab | Get-AzLabVm -ClaimByUser $user
 $today  = (Get-Date).ToString()
 $end    = (Get-Date).AddMonths(4).ToString()
 
-$lab `
-    | New-AzLabSchedule -Frequency Weekly -FromDate $today -ToDate $end -StartTime '10:00' -EndTime '11:00' -Notes 'A classroom note.' `
-    | Get-AzLabSchedule `
-    | Remove-AzLabSchedule
+$lab | New-AzLabSchedule -Frequency Weekly -FromDate $today -ToDate $end -StartTime '10:00' -EndTime '11:00' -Notes 'A classroom note.' | Out-Null
+$lab | Get-AzLabSchedule `
+     | Remove-AzLabSchedule
 
 $lab | Remove-AzLabuser -User $user
 $lab | Remove-AzLab

--- a/samples/ClassroomLabs/Modules/Library/Tests/Cleanup.ps1
+++ b/samples/ClassroomLabs/Modules/Library/Tests/Cleanup.ps1
@@ -1,0 +1,18 @@
+[cmdletbinding()]
+Param()
+Import-Module $PSScriptRoot\..\Az.LabServices.psm1
+
+. $PSScriptRoot\Utils.ps1
+
+$rg  = Get-FastResourceGroup
+$la  = Get-FastLabAccount
+$lab = Get-FastLab
+
+Describe 'Cleanup resources as might get left dangling' {
+    It 'Can cleanup everything' {
+            
+        Get-AzLabAccount -ResourceGroupName $rg.ResourceGroupName | Where-Object {$_.Name.StartsWith('Temp')} | Remove-AzLabAccount
+        $la | Get-AzLab | Where-Object {$_.Name.StartsWith('Temp')} | Remove-AzLab
+        $lab | Get-AzLabSchedule | Remove-AzLabSchedule
+    }    
+}

--- a/samples/ClassroomLabs/Modules/Library/Tests/Cleanup.ps1
+++ b/samples/ClassroomLabs/Modules/Library/Tests/Cleanup.ps1
@@ -13,6 +13,6 @@ Describe 'Cleanup resources as might get left dangling' {
             
         Get-AzLabAccount -ResourceGroupName $rg.ResourceGroupName | Where-Object {$_.Name.StartsWith('Temp')} | Remove-AzLabAccount
         $la | Get-AzLab | Where-Object {$_.Name.StartsWith('Temp')} | Remove-AzLab
-        $lab | Get-AzLabSchedule | Remove-AzLabSchedule
+        $lab | Get-AzLabSchedule | Where-Object {$_.properties.start -lt (Get-Date).AddDays(-7)} | Remove-AzLabSchedule
     }    
 }

--- a/samples/ClassroomLabs/Modules/Library/Tests/Fast-SharedGallery.test.ps1
+++ b/samples/ClassroomLabs/Modules/Library/Tests/Fast-SharedGallery.test.ps1
@@ -7,8 +7,23 @@ Import-Module $PSScriptRoot\..\Az.LabServices.psm1
 $la = Get-FastLabAccount
 $sg = Get-FastGallery
 
+$mtx = New-Object System.Threading.Mutex($false, "231db620-9fec-4a20-86dd-31812d055325")
+
+# This is an example where I can't think of a way to make the test multi-thread safe without using a mutex
 Describe 'Shared Gallery Management' {
-    It 'Can attach a shared library' {
+    It 'Can attach/detach a shared library' {
+
+        try {
+            if($mtx.WaitOne(60 * 60 * 1000)) {
+                # We have the mutex. Move on to main logic after the catch clause.
+            } else {
+                $false | Should -BeTrue -Because "Can't get the mutex before timing out"
+            }
+
+        } catch [System.Threading.AbandonedMutexException] {
+            # This means a previous test crashed before releasing the mutex, trying to bring the lab in the correct initial state
+            $la | Remove-AzLabAccountSharedGallery -SharedGalleryName $sg.Name
+        }
             
         $sg | Should -Not -Be $null
 
@@ -18,9 +33,7 @@ Describe 'Shared Gallery Management' {
         $imgs = $la | Get-AzLabAccountSharedImage
         $imgs.Count | Should -BeGreaterThan 0
 
-    }
-
-    It 'Can detach a shared library' {
-        $la | Remove-AzLabAccountSharedGallery -SharedGalleryName $sg.Name  
+        $la | Remove-AzLabAccountSharedGallery -SharedGalleryName $sg.Name
+        $mtx.ReleaseMutex()  
     }    
 }

--- a/samples/ClassroomLabs/Modules/Library/Tests/Fast-SharedGallery.test.ps1
+++ b/samples/ClassroomLabs/Modules/Library/Tests/Fast-SharedGallery.test.ps1
@@ -4,28 +4,14 @@ Import-Module $PSScriptRoot\..\Az.LabServices.psm1
 
 . $PSScriptRoot\Utils.ps1
 
-$la = Get-FastLabAccount
+$la = Get-FastLabAccount -Random
 $sg = Get-FastGallery
 
-$mtx = New-Object System.Threading.Mutex($false, "231db620-9fec-4a20-86dd-31812d055325")
-
-# This is an example where I can't think of a way to make the test multi-thread safe without using a mutex
 Describe 'Shared Gallery Management' {
     It 'Can attach/detach a shared library' {
-
-        try {
-            if($mtx.WaitOne(60 * 60 * 1000)) {
-                # We have the mutex. Move on to main logic after the catch clause.
-            } else {
-                $false | Should -BeTrue -Because "Can't get the mutex before timing out"
-            }
-
-        } catch [System.Threading.AbandonedMutexException] {
-            # This means a previous test crashed before releasing the mutex, trying to bring the lab in the correct initial state
-            $la | Remove-AzLabAccountSharedGallery -SharedGalleryName $sg.Name
-        }
             
         $sg | Should -Not -Be $null
+        $la | Should -Not -Be $null
 
         $acsg = $la | New-AzLabAccountSharedGallery -SharedGallery $sg
         $acsg | Should -Not -Be $null
@@ -34,6 +20,6 @@ Describe 'Shared Gallery Management' {
         $imgs.Count | Should -BeGreaterThan 0
 
         $la | Remove-AzLabAccountSharedGallery -SharedGalleryName $sg.Name
-        $mtx.ReleaseMutex()  
+        $la | Remove-AzLabAccount
     }    
 }

--- a/samples/ClassroomLabs/Modules/Library/Tests/LabAccount.test.ps1
+++ b/samples/ClassroomLabs/Modules/Library/Tests/LabAccount.test.ps1
@@ -4,7 +4,7 @@ Import-Module $PSScriptRoot\..\Az.LabServices.psm1
 
 $rgName     = 'AzLabsLibrary'
 $rgLocation = 'West Europe'
-$laName     = 'AzLabsLibrary-la' + (Get-Random)
+$laName     = 'Temp' + (Get-Random)
 
 Describe 'Lab Account Crud' {
         It 'Can create a Lab Account' {

--- a/samples/ClassroomLabs/Modules/Library/Tests/Utils.ps1
+++ b/samples/ClassroomLabs/Modules/Library/Tests/Utils.ps1
@@ -15,20 +15,35 @@ $descr = 'Bringing it to the 21st Century'
 $userName = 'test0000'
 $password = 'Test000'
 
-function Get-FastLabAccount {
+function Get-FastResourceGroup {
     [CmdletBinding()]
     param()
 
-    # Creat RG, Lab Account and lab if not existing
-    if (-not (Get-AzResourceGroup -ResourceGroupName $rgName -EA SilentlyContinue)) {
+    $rg = Get-AzResourceGroup -ResourceGroupName $rgName -EA SilentlyContinue
+    if (-not $rg) {
         New-AzResourceGroup -ResourceGroupName $rgName -Location $rgLocation | Out-null
         Write-Verbose "$rgname resource group didn't exist. Created it."
     }
+    return $rg
+}
 
-    $la = Get-AzLabAccount -ResourceGroupName $rgName -LabAccountName $laName
+function Get-FastLabAccount {
+    [CmdletBinding()]
+    param([Switch]$RandomName = $false)
+
+    # Creat RG, Lab Account and lab if not existing
+    Get-FastResourceGroup | Out-Null
+    
+    if($RandomName) {
+        $laRealName = 'Temp' + (Get-Random)
+    } else {
+        $laRealName = $laName
+    }
+
+    $la = Get-AzLabAccount -ResourceGroupName $rgName -LabAccountName $laRealName
     if (-not $la) {
-        $la = New-AzLabAccount -ResourceGroupName $rgName -LabAccountName $laName
-        Write-Verbose "$laName lab account created."                
+        $la = New-AzLabAccount -ResourceGroupName $rgName -LabAccountName $laRealName
+        Write-Verbose "$laRealName lab account created."                
     }
     return $la
 }


### PR DESCRIPTION
- There was a chance tests would have a race condition as multiple parallel builds were accessing same resource in a non multi-threaded way
- Changed scripts to create temporary resources in the AzLabsServices RG starting with the string Temp
- Created Cleanup script that deletes all 'Temp*' resources that might have left dangling and setting it to run after every build.