### PR TITLE
Moving DTL Tests to the new framework

### DIFF
--- a/samples/DevTestLabs/Modules/Library/Tests/RunPesterTests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/RunPesterTests.ps1
@@ -6,7 +6,7 @@ Param(
     [bool] $VerboseTests = $false
 )
 
-Import-Module $PSScriptRoot\..\Az.LabServices.psm1
+Import-Module $PSScriptRoot\..\Az.DevTestLabs2.psm1
 
 # This allows the parallel tests not to give up on all of them when one test fails. Using just 'Continue' doesn't do it. Mystery.
 $ErrorActionPreference="SilentlyContinue"


### PR DESCRIPTION
This PR moves the DTL tests to the new framework (aka hosting in azure and reporting tests). The only thing left to do is to separate them as slow/fast.  I have done a sample run (all green) and seems to work. I have not tested a failure case, but it should logically behave as the Az.LabServices one by failing the publishing step.