### PR TITLE
Add TLS1.1 and TLS1.2 as security protocols

### DIFF
--- a/Artifacts/windows-ConfigurationManagerTechnicalPreview/setupCMCB.ps1
+++ b/Artifacts/windows-ConfigurationManagerTechnicalPreview/setupCMCB.ps1
@@ -8,6 +8,11 @@ cd $($PSScriptRoot)
 #Check if System is Domain-Joined
 if((gwmi win32_computersystem).partofdomain -eq $true)
 {
+	#Add TLS 1.1, TLS 1.2 to security protocol
+	IF ([System.Net.ServicePointManager]::SecurityProtocol -notmatch "^(?=.*\bTls12\b)(?=.*\bTls11\b).*$") {
+		[System.Net.ServicePointManager]::SecurityProtocol = @([System.Net.ServicePointManager]::SecurityProtocol, [System.Net.SecurityProtocolType]::Tls12, [System.Net.SecurityProtocolType]::Tls11)
+	}
+	
 	#Download RZUpdate if missing...
 	if((Test-Path "$($env:temp)\RZUpdate.exe") -eq $false) 
 	{ 

--- a/Artifacts/windows-ConfigurationManagerTechnicalPreview/setupCMCB.ps1
+++ b/Artifacts/windows-ConfigurationManagerTechnicalPreview/setupCMCB.ps1
@@ -8,9 +8,9 @@ cd $($PSScriptRoot)
 #Check if System is Domain-Joined
 if((gwmi win32_computersystem).partofdomain -eq $true)
 {
-	#Add TLS 1.1, TLS 1.2 to security protocol
-	IF ([System.Net.ServicePointManager]::SecurityProtocol -notmatch "^(?=.*\bTls12\b)(?=.*\bTls11\b).*$") {
-		[System.Net.ServicePointManager]::SecurityProtocol = @([System.Net.ServicePointManager]::SecurityProtocol, [System.Net.SecurityProtocolType]::Tls12, [System.Net.SecurityProtocolType]::Tls11)
+	#Force usage of TLS 1.2
+	IF ([System.Net.ServicePointManager]::SecurityProtocol -notmatch "^(?=.*\bTls12\b).*$") {
+		[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 	}
 	
 	#Download RZUpdate if missing...

--- a/Artifacts/windows-ConfigurationManagerTechnicalPreview/setupCMCB.ps1
+++ b/Artifacts/windows-ConfigurationManagerTechnicalPreview/setupCMCB.ps1
@@ -9,9 +9,7 @@ cd $($PSScriptRoot)
 if((gwmi win32_computersystem).partofdomain -eq $true)
 {
 	#Force usage of TLS 1.2
-	IF ([System.Net.ServicePointManager]::SecurityProtocol -notmatch "^(?=.*\bTls12\b).*$") {
-		[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
-	}
+	[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 	
 	#Download RZUpdate if missing...
 	if((Test-Path "$($env:temp)\RZUpdate.exe") -eq $false) 


### PR DESCRIPTION
The download of the files (specifically RZupdate.exe) failed, if the security protocol does not contains TLS 1.1 or TLS 1.2.
To fix this, TLS 1.1 and TLS 1.2 are added to the currently used security protocols.