### PR TITLE
Fixed parameter type mismatch for run-bash artifact

### DIFF
--- a/Artifacts/linux-run-bash/Artifactfile.json
+++ b/Artifacts/linux-run-bash/Artifactfile.json
@@ -30,7 +30,7 @@
             "displayName": "Skip dos2unix conversion",
             "description": "Skip the script conversion from MSDOS to Unix line ending",
             "allowEmpty": true,
-            "defaultValue": "true"
+            "defaultValue": true
         }
     },
     "runAzureVMExtension": {


### PR DESCRIPTION
skipDos2Unix parameter expects a bool `true` or `false`. Fixed defaultValue to return `true` (previously `"true"`)