### PR TITLE
Created windows artifact for adding a user to a local group

### DIFF
--- a/Artifacts/windows-add-user-to-group/Artifactfile.json
+++ b/Artifacts/windows-add-user-to-group/Artifactfile.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
+  "title": "Add user to user group",
+  "description": "Adds a user account to a user group on the targetted virtual machine.",
+  "publisher": "Microsoft",
+  "tags": [
+    "Windows"
+  ],
+  "targetOsType": "Windows",
+  "parameters": {
+    "username": {
+      "type": "string",
+      "displayName": "User account",
+      "description": "The user account that will be added to the provided user group of the target virtual machine."
+    },
+    "group": {
+      "type": "string",
+      "displayName": "Group",
+      "description": "The group that the user will be added to on the target virtual machine."
+    }
+  },
+  "runCommand": {
+    "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./addUserToGroup.ps1', ' -Username ', parameters('username'), ' -Group ', parameters('group'), '\"')]"
+  }
+}

--- a/Artifacts/windows-add-user-to-group/Artifactfile.json
+++ b/Artifacts/windows-add-user-to-group/Artifactfile.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
   "title": "Add user to group",
-  "description": "Adds a user account to a group on the targetted virtual machine.",
+  "description": "Adds a user to a group on the targetted virtual machine. You can also use this artifact to add a group to another group.",
   "publisher": "Microsoft",
   "tags": [
     "Windows"
@@ -10,8 +10,8 @@
   "parameters": {
     "username": {
       "type": "string",
-      "displayName": "User account",
-      "description": "The user account that will be added to the provided group on the target virtual machine."
+      "displayName": "User",
+      "description": "The user that will be added to the provided group on the target virtual machine. You can also use a group here instead of a user."
     },
     "group": {
       "type": "string",

--- a/Artifacts/windows-add-user-to-group/Artifactfile.json
+++ b/Artifacts/windows-add-user-to-group/Artifactfile.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
   "title": "Add user to user group",
-  "description": "Adds a user account to a user group on the targetted virtual machine.",
+  "description": "Adds a user account to a group on the targetted virtual machine.",
   "publisher": "Microsoft",
   "tags": [
     "Windows"
@@ -11,7 +11,7 @@
     "username": {
       "type": "string",
       "displayName": "User account",
-      "description": "The user account that will be added to the provided user group of the target virtual machine."
+      "description": "The user account that will be added to the provided group on the target virtual machine."
     },
     "group": {
       "type": "string",

--- a/Artifacts/windows-add-user-to-group/Artifactfile.json
+++ b/Artifacts/windows-add-user-to-group/Artifactfile.json
@@ -20,6 +20,6 @@
     }
   },
   "runCommand": {
-    "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./addUserToGroup.ps1', ' -Username ', parameters('username'), ' -Group ', parameters('group'), '\"')]"
+    "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./addUserToGroup.ps1', ' -Username ', \"parameters('username')\", ' -Group ', \"parameters('group')\", '\"')]"
   }
 }

--- a/Artifacts/windows-add-user-to-group/Artifactfile.json
+++ b/Artifacts/windows-add-user-to-group/Artifactfile.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
-  "title": "Add user to user group",
+  "title": "Add user to group",
   "description": "Adds a user account to a group on the targetted virtual machine.",
   "publisher": "Microsoft",
   "tags": [

--- a/Artifacts/windows-add-user-to-group/Artifactfile.json
+++ b/Artifacts/windows-add-user-to-group/Artifactfile.json
@@ -20,6 +20,6 @@
     }
   },
   "runCommand": {
-    "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./addUserToGroup.ps1', ' -Username ', \"parameters('username')\", ' -Group ', \"parameters('group')\", '\"')]"
+    "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./addUserToGroup.ps1', ' -Username ''', parameters('username'), ''' -Group ''', parameters('group'), '''\"')]"
   }
 }

--- a/Artifacts/windows-add-user-to-group/addUserToGroup.ps1
+++ b/Artifacts/windows-add-user-to-group/addUserToGroup.ps1
@@ -1,0 +1,66 @@
+﻿#
+# Functions used in this script.
+#
+
+function Handle-LastError
+{
+    [CmdletBinding()]
+    param(
+    )
+
+    $message = $error[0].Exception.Message
+    if ($message)
+    {
+        Write-Host -Object "ERROR: $message" -ForegroundColor Red
+    }
+    
+    # IMPORTANT NOTE: Throwing a terminating error (using $ErrorActionPreference = "Stop") still
+    # returns exit code zero from the PowerShell script when using -File. The workaround is to
+    # NOT use -File when calling this script and leverage the try-catch-finally block and return
+    # a non-zero exit code from the catch block.
+    exit -1
+}
+
+function Validate-Params
+{
+    [CmdletBinding()]
+    param(
+    )
+
+    if ([string]::IsNullOrEmpty($Username))
+    {
+        throw 'Username parameter is required.'
+    }
+    if ([string]::IsNullOrEmpty($Group))
+    {
+        throw 'Group parameter is required.'
+    }
+}
+
+
+###################################################################################################
+
+#
+# PowerShell configurations
+#
+
+# NOTE: Because the $ErrorActionPreference is "Stop", this script will stop on first failure.
+#       This is necessary to ensure we capture errors inside the try-catch-finally block.
+$ErrorActionPreference = "Stop"
+
+###################################################################################################
+
+#
+# Main execution block.
+#
+
+try
+{
+    Validate-Params
+
+    Add-LocalGroupMember -Group $Group -Member $Username
+}
+catch
+{
+    Handle-LastError
+}

--- a/Artifacts/windows-add-user-to-group/addUserToGroup.ps1
+++ b/Artifacts/windows-add-user-to-group/addUserToGroup.ps1
@@ -1,5 +1,4 @@
 ﻿# Parameters for this script file.
-#
 
 [CmdletBinding()]
 param(

--- a/Artifacts/windows-add-user-to-group/addUserToGroup.ps1
+++ b/Artifacts/windows-add-user-to-group/addUserToGroup.ps1
@@ -1,4 +1,15 @@
-﻿#
+﻿# Parameters for this script file.
+#
+
+[CmdletBinding()]
+param(
+    [string] $Username,
+    [string] $Group
+)
+
+###################################################################################################
+
+#
 # Functions used in this script.
 #
 


### PR DESCRIPTION
This artifact is helpful for when you're using the [windows-docker](https://github.com/Azure/azure-devtestlab/tree/master/Artifacts/windows-docker) artifact since you'll be unable to start the docker daemon unless your user account is part of the "docker-users" group which isn't always automatically set properly. Its not specific to that scenario of course but this is the reason why I was hoping it could be added.

You can also use this artifact to add a group to another group.