### PR TITLE
Splitting install of multiple choco packages

### DIFF
--- a/Artifacts/windows-7zip/install-choco-package.ps1
+++ b/Artifacts/windows-7zip/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-awscli/install-choco-package.ps1
+++ b/Artifacts/windows-awscli/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-azurepowershell/install-choco-package.ps1
+++ b/Artifacts/windows-azurepowershell/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-beyond-compare/install-choco-package.ps1
+++ b/Artifacts/windows-beyond-compare/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-chocolatey/install-choco-package.ps1
+++ b/Artifacts/windows-chocolatey/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-chrome/install-choco-package.ps1
+++ b/Artifacts/windows-chrome/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-dotnet45/install-choco-package.ps1
+++ b/Artifacts/windows-dotnet45/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-eclipse/install-choco-package.ps1
+++ b/Artifacts/windows-eclipse/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-firefox/install-choco-package.ps1
+++ b/Artifacts/windows-firefox/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-git/install-choco-package.ps1
+++ b/Artifacts/windows-git/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-intellij/install-choco-package.ps1
+++ b/Artifacts/windows-intellij/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-mongodb/install-choco-package.ps1
+++ b/Artifacts/windows-mongodb/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-node/install-choco-package.ps1
+++ b/Artifacts/windows-node/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-notepadplusplus/install-choco-package.ps1
+++ b/Artifacts/windows-notepadplusplus/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-nvm/install-choco-package.ps1
+++ b/Artifacts/windows-nvm/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-putty/install-choco-package.ps1
+++ b/Artifacts/windows-putty/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-remote-desktop-connection-manager/install-choco-package.ps1
+++ b/Artifacts/windows-remote-desktop-connection-manager/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-selenium/install-choco-package.ps1
+++ b/Artifacts/windows-selenium/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-ssms/install-choco-package.ps1
+++ b/Artifacts/windows-ssms/install-choco-package.ps1
@@ -1,4 +1,4 @@
-##################################################################################################>
+##################################################################################################
 #
 # Parameters to this script file.
 #
@@ -8,6 +8,12 @@ param(
     # Space-, comma- or semicolon-separated list of Chocolatey packages.
     [string] $Packages,
 
+    # Boolean indicating if we should allow empty checksums. Default to true to match previous artifact functionality despite security
+    [bool] $AllowEmptyChecksums = $true,
+
+    # Boolean indicating if we should ignore checksums. Default to false for security
+    [bool] $IgnoreChecksums = $false,
+    
     # Minimum PowerShell version required to execute this script.
     [int] $PSVersionRequired = 3
 )
@@ -94,9 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $expression = "$ChocoExePath install -y -f --acceptlicense --allow-empty-checksums --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
+    }
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-sublime-text/install-choco-package.ps1
+++ b/Artifacts/windows-sublime-text/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-sysinternals/install-choco-package.ps1
+++ b/Artifacts/windows-sysinternals/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl

--- a/Artifacts/windows-webdeploy/install-choco-package.ps1
+++ b/Artifacts/windows-webdeploy/install-choco-package.ps1
@@ -100,18 +100,20 @@ function Install-Packages
         $Packages
     )
 
-    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries) -join ' '
-    $checkSumFlags = ""
-    if ($AllowEmptyChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+    $Packages = $Packages.split(',; ', [StringSplitOptions]::RemoveEmptyEntries)
+    $Packages | % {
+        $checkSumFlags = ""
+        if ($AllowEmptyChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --allow-empty-checksums "
+        }
+        if ($IgnoreChecksums)
+        {
+            $checkSumFlags = $checkSumFlags + " --ignore-checksums "
+        }
+        $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $_"
+        Invoke-ExpressionImpl -Expression $expression
     }
-    if ($IgnoreChecksums)
-    {
-        $checkSumFlags = $checkSumFlags + " --ignore-checksums "
-    }
-    $expression = "$ChocoExePath install -y -f --acceptlicense $checkSumFlags --no-progress --stoponfirstfailure $Packages"
-    Invoke-ExpressionImpl -Expression $expression 
 }
 
 function Invoke-ExpressionImpl


### PR DESCRIPTION
Chocolatey seems to have a bug that causes installation of multiple packages to fail. To mitigate, we split the package list and install one package at a time. Because we currently copy the choco install file to the affected artifacts, we need to apply the fix to all to keep them consistent for future updates.