### PR TITLE
Fix for VM pipeline test running too fast

### DIFF
--- a/samples/DevTestLabs/Modules/Library/Tests/Vm-Pipeline.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Vm-Pipeline.tests.ps1
@@ -53,6 +53,10 @@ Describe 'VM Management' {
 
             $vms | Remove-AzDtlVm
 
+            # If we query DTL too fast before they update records, the VM will still show up
+            # need to wait for DTL to catch up - only happens occasionally
+            Start-Sleep -Seconds 60
+
             $vms = $labs | Get-AzDtlVm
             Write-Verbose "VMs after delete"
             $vms | Out-String | Write-Verbose


### PR DESCRIPTION
After running this test often, it looks like we are querying DTL for VMs too fast after deleting them which is failing the test (we expected the VM to be deleted but it's still showing up when we query for the VMs).  Adding a pause to let DTL catch up with the delete before checking if the VM was really deleted.