### PR TITLE
Adding retries to tests for shared image gallery support

### DIFF
--- a/samples/DevTestLabs/Modules/Library/Tests/Lab-SharedImageGallery.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Lab-SharedImageGallery.tests.ps1
@@ -84,13 +84,21 @@ Describe  'Get and Set SharedImageGallery and SharedImageGalleryImages' {
             # We have to slow down our script a bit, give the back end time to catch up on processing the list of images from SIG over to DTL
             Start-Sleep -Seconds 60
             $SIG | Set-AzDtlLabSharedImageGalleryImages -ImageName $image.definitionName -OsType $image.osType -ImageType $image.imageType -Enabled $false
-            Start-Sleep -Seconds 60
-
+            
             # Get the images, confirm it was set the right way
-            ($SIG | Get-AzDtlLabSharedImageGalleryImages | Where-Object {$_.OsType -eq "Windows"} | Select-Object -First 1).enableState | Should -Be "Disabled"
+            $sigImageResult = ($SIG | Get-AzDtlLabSharedImageGalleryImages | Where-Object {$_.OsType -eq "Windows"} | Select-Object -First 1).enableState
 
-            # We have to slow down our script a bit, ensure the previous call has time to propogate in DTL
-            Start-Sleep -Seconds 60
+            # There are times when it takes a few min for everything to propogate...  Let's check and try again
+            $count = 10
+            while ($sigImageResult -eq $null -and $count -gt 0) {
+                # delay for a little bit and try again
+                Start-Sleep -Seconds 60
+                $count --
+                Write-Verbose "Getting the SIG windows image enabled state again - count: $count"
+                $sigImageResult = ($SIG | Get-AzDtlLabSharedImageGalleryImages | Where-Object {$_.OsType -eq "Windows"} | Select-Object -First 1).enableState
+            }
+
+            $sigImageResult | Should -Be "Disabled"
             
             # Set again, to enabled
             $SIG = $lab | Get-AzDtlLabSharedImageGallery -IncludeImages


### PR DESCRIPTION
We are still seeing failures for Shared Image Gallery support - we are doing a 'set' and then directly after a 'get' to see the results and are seeing failures.  Adding some retries to see if waiting some minutes will work.