### PR TITLE
Fix output message

### DIFF
--- a/Artifacts/windows-add-local-admin/artifact.ps1
+++ b/Artifacts/windows-add-local-admin/artifact.ps1
@@ -155,5 +155,5 @@ function Add-UserToLocalGroup ()
 $adminGroupName = Get-LocalAdminGroupName
 Add-UserToLocalGroup -Username $DomainJoinUsername -GroupName $adminGroupName
 
-Write-Output "Members of $GroupName are:"
+Write-Output "Members of $adminGroupName are:"
 Get-LocalGroupMembers $adminGroupName


### PR DESCRIPTION
incorrect variable used when outputting the admin group name to stdout