### PR TITLE
Fix DTL Library tests

### DIFF
--- a/samples/DevTestLabs/Modules/Library/Tests/Lab-SharedImageGallery.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Lab-SharedImageGallery.tests.ps1
@@ -105,7 +105,18 @@ Describe  'Get and Set SharedImageGallery and SharedImageGalleryImages' {
             $SIG | Set-AzDtlLabSharedImageGalleryImages -ImageName $image.definitionName -OsType $image.osType -ImageType $image.imageType -Enabled $true
             
             # Get the images, confirm it was set the right way
-            ($SIG | Get-AzDtlLabSharedImageGalleryImages | Where-Object {$_.OsType -eq "Windows"} | Select-Object -First 1).enableState | Should -Be "Enabled"
+
+            # There are times when it takes a few min for everything to propogate...  Let's check and try again
+            $count = 10
+            while ($sigImageResult -eq $null -and $count -gt 0) {
+                # delay for a little bit and try again
+                Start-Sleep -Seconds 60
+                $count --
+                Write-Verbose "Getting the SIG windows image enabled state again - count: $count"
+                $sigImageResult = ($SIG | Get-AzDtlLabSharedImageGalleryImages | Where-Object {$_.OsType -eq "Windows"} | Select-Object -First 1).enableState
+            }
+
+            $sigImageResult | Should -Be "Enabled"
 
         }
 

--- a/samples/DevTestLabs/Modules/Library/Tests/Vm-ExtendedStatus.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Vm-ExtendedStatus.tests.ps1
@@ -8,7 +8,7 @@ $lab = @(
 )
 
 $vm = @(
-    [pscustomobject]@{VmName=('Vm-' + (Get-Random)); Size='Standard_A4_v2'; UserName='bob'; Password='aPassword341341'; OsType='Windows'; Sku='2012-R2-Datacenter'; Publisher='MicrosoftWindowsServer'; Offer='WindowsServer'}
+    [pscustomobject]@{VmName=('Vm-' + (Get-Random)); Size='Standard_B4ms'; UserName='bob'; Password='aPassword341341'; OsType='Windows'; Sku='2012-R2-Datacenter'; Publisher='MicrosoftWindowsServer'; Offer='WindowsServer'}
 )
 
 Describe  'Virtual Machine Tests' {

--- a/samples/DevTestLabs/Modules/Library/Tests/Vm-Pipeline.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Vm-Pipeline.tests.ps1
@@ -9,8 +9,8 @@ $labs = @(
 )
 
 $vms = @(
-    [pscustomobject]@{VmName=('Vm-' + (Get-Random)); Size='Standard_A4_v2'; UserName='bob'; Password='aPassword341341'; OsType='Windows'; Sku='2012-R2-Datacenter'; Publisher='MicrosoftWindowsServer'; Offer='WindowsServer'}
-    [pscustomobject]@{VmName=('Vm-' + (Get-Random)); Size='Standard_A4_v2'; UserName='bob'; Password='aPassword341341'; OsType='Windows'; Sku='2012-R2-Datacenter'; Publisher='MicrosoftWindowsServer'; Offer='WindowsServer'}
+    [pscustomobject]@{VmName=('Vm-' + (Get-Random)); Size='Standard_B4ms'; UserName='bob'; Password='aPassword341341'; OsType='Windows'; Sku='2012-R2-Datacenter'; Publisher='MicrosoftWindowsServer'; Offer='WindowsServer'}
+    [pscustomobject]@{VmName=('Vm-' + (Get-Random)); Size='Standard_B4ms'; UserName='bob'; Password='aPassword341341'; OsType='Windows'; Sku='2012-R2-Datacenter'; Publisher='MicrosoftWindowsServer'; Offer='WindowsServer'}
 )
 
 Describe 'VM Management' {

--- a/samples/DevTestLabs/Modules/Library/Tests/Vm-Properties.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Vm-Properties.tests.ps1
@@ -8,7 +8,7 @@ $lab = @(
 )
 
 $vm = @(
-    [pscustomobject]@{VmName=('Vm-' + (Get-Random)); Size='Standard_A4_v2'; UserName='bob'; Password='aPassword341341'; OsType='Windows'; Sku='2012-R2-Datacenter'; Publisher='MicrosoftWindowsServer'; Offer='WindowsServer'}
+    [pscustomobject]@{VmName=('Vm-' + (Get-Random)); Size='Standard_B4ms'; UserName='bob'; Password='aPassword341341'; OsType='Windows'; Sku='2012-R2-Datacenter'; Publisher='MicrosoftWindowsServer'; Offer='WindowsServer'}
 )
 
 Describe 'Virtual Machine Management' {


### PR DESCRIPTION
We are seeing timeouts for the tests - we have 2 issues:
1)  Shared Image Gallery API calls return but properties aren't set when we query immediately after.  We need to wait a little for the properties to propagate
2)  VM tests are timing out (60 min max), trying to switch to burstable VMs (faster) to see if this resolves the timeout