### PR TITLE
TESTS ONLY:  Multiple improvements to DTL Library Tests

### DIFF
--- a/samples/DevTestLabs/Modules/Library/Tests/Lab-AllowedVmSizes.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Lab-AllowedVmSizes.tests.ps1
@@ -4,7 +4,7 @@ Param()
 Import-Module $PSScriptRoot\..\Az.DevTestLabs2.psm1 -Verbose:$false
 
 $lab = @(
-    [pscustomobject]@{Name=('DtlLibrary-LabPolicy-' + (Get-Random)); ResourceGroupName=('DtlLibrary-LabPolicyRg-' + (Get-Random)); Location='westus'}
+    [pscustomobject]@{Name=('DtlLibrary-LabSizes-' + (Get-Random)); ResourceGroupName=('DtlLibrary-LabSizesRg-' + (Get-Random)); Location='westus'}
 )
 
 Describe  'Get and Set Allowed VM Sizes Policy' {

--- a/samples/DevTestLabs/Modules/Library/Tests/Lab-Pipeline.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Lab-Pipeline.tests.ps1
@@ -4,8 +4,8 @@ Param()
 Import-Module $PSScriptRoot\..\Az.DevTestLabs2.psm1 -Verbose:$false
 
 $labs = @(
-    [pscustomobject]@{Name=('DtlLibrary-Lab-' + (Get-Random)); ResourceGroupName=('DtlLibrary-LabRg-' + (Get-Random)); Location='westus'},
-    [pscustomobject]@{Name=('DtlLibrary-Lab-' + (Get-Random)); ResourceGroupName=('DtlLibrary-LabRg-' + (Get-Random)); Location='eastus'}
+    [pscustomobject]@{Name=('DtlLibrary-LabPipeline-' + (Get-Random)); ResourceGroupName=('DtlLibrary-LabPipelineRg-' + (Get-Random)); Location='westus'},
+    [pscustomobject]@{Name=('DtlLibrary-LabPipeline-' + (Get-Random)); ResourceGroupName=('DtlLibrary-LabPipelineRg-' + (Get-Random)); Location='eastus'}
 )
 
 Describe  'Lab Creation and Deletion' {
@@ -18,16 +18,17 @@ Describe  'Lab Creation and Deletion' {
             $labs | Select-Object -Property @{N='Name'; E={$_.ResourceGroupName}}, Location | New-AzureRmResourceGroup -Force | Out-Null
 
             # Create the labs
-            $createdLabs = $labs | New-AzDtlLab
+            $labs | New-AzDtlLab
+
+            # Query Azure to get the created labs to make sure they really exist
+            $createdLabs = $labs | Get-AzDtlLab
 
             # Check the number of labs created and that they were successful
             $createdLabs.Count | Should -Be 2
+
             foreach ($lab in $createdLabs) {
                 $lab.Properties.provisioningState | Should -Be "Succeeded"
             }
-
-            # Check that the labs really exist
-            $createdLabs | Get-AzDtlLab | Should -Not -Be $null
 
         }
 

--- a/samples/DevTestLabs/Modules/Library/Tests/Lab-SharedImageGallery.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Lab-SharedImageGallery.tests.ps1
@@ -4,7 +4,7 @@ Param()
 Import-Module $PSScriptRoot\..\Az.DevTestLabs2.psm1 -Verbose:$false
 
 $lab = @(
-    [pscustomobject]@{Name=('DtlLibrary-LabPolicy-' + (Get-Random)); ResourceGroupName=('DtlLibrary-LabPolicyRg-' + (Get-Random)); Location='westus'}
+    [pscustomobject]@{Name=('DtlLibrary-LabSIG-' + (Get-Random)); ResourceGroupName=('DtlLibrary-LabSIGRg-' + (Get-Random)); Location='westus'}
 )
 
 # We are using an existing shared image gallery for this test, not ideal (external dependency) but takes to long to build it up and tear down every time

--- a/samples/DevTestLabs/Modules/Library/Tests/Scenario-AllFeatures.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Scenario-AllFeatures.ps1
@@ -9,9 +9,9 @@ function StringToFile([parameter(ValueFromPipeline=$true)][string] $text) {
   return $tmp.FullName
 }
 
-$lab1 = "DtlLibraryTest" + (Get-Random)
-$lab2 = "DtlLibraryTest" + (Get-Random)
-$rgName = "DtlLibraryTestRG" + (Get-Random)
+$lab1 = "DtlLibrary-ScenarioAll-" + (Get-Random)
+$lab2 = "DtlLibrary-ScenarioAll2-" + (Get-Random)
+$rgName = "DtlLibrary-ScenarioAll-rg-" + (Get-Random)
 
 $labsData = @"
 Name, ResourceGroupName

--- a/samples/DevTestLabs/Modules/Library/Tests/Scenario-MultipleLabsFromCsv.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Scenario-MultipleLabsFromCsv.ps1
@@ -12,9 +12,9 @@ function StringToFile([parameter(ValueFromPipeline=$true)][string] $text) {
   return $tmp.FullName
 }
 
-$lab1 = "DtlLibraryTest" + (Get-Random)
-$lab2 = "DtlLibraryTest" + (Get-Random)
-$rgName = "DtlLibraryTestRG" + (Get-Random)
+$lab1 = "DtlLibrary-ScenarioLabs-" + (Get-Random)
+$lab2 = "DtlLibrary-ScenarioLabs2-" + (Get-Random)
+$rgName = "DtlLibrary-ScenarioLabs-rg-" + (Get-Random)
 
 $vms = @"
 Name, ResourceGroupName, VmName, Size, UserName, Password, OsType, Sku, Publisher, Offer

--- a/samples/DevTestLabs/Modules/Library/Tests/Scenario-MultipleVMsFromCsv.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Scenario-MultipleVMsFromCsv.ps1
@@ -6,8 +6,8 @@ Param()
 
 Import-Module $PSScriptRoot\..\Az.DevTestLabs2.psm1 -Verbose:$false
 
-$rgName = "DtlLibraryTestRG" + (Get-Random)
-$labname = "DtlLibraryTest" + (Get-Random)
+$rgName = "DtlLibrary-ScenarioVMs-rg-" + (Get-Random)
+$labname = "DtlLibrary-ScenarioVMs-" + (Get-Random)
 
 $vms = @'
 VmName, Size, UserName, Password, OsType, Sku, Publisher, Offer

--- a/samples/DevTestLabs/Modules/Library/Tests/Vm-ExtendedStatus.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Vm-ExtendedStatus.tests.ps1
@@ -4,7 +4,7 @@ Param()
 Import-Module $PSScriptRoot\..\Az.DevTestLabs2.psm1 -Verbose:$false
 
 $lab = @(
-    [pscustomobject]@{Name=('DtlLibrary-Vm-' + (Get-Random)); ResourceGroupName=('DtlLibrary-VmRg-' + (Get-Random)); Location='eastus'}
+    [pscustomobject]@{Name=('DtlLibrary-VmExtended-' + (Get-Random)); ResourceGroupName=('DtlLibrary-VmExtendedRg-' + (Get-Random)); Location='eastus'}
 )
 
 $vm = @(

--- a/samples/DevTestLabs/Modules/Library/Tests/Vm-Pipeline.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Vm-Pipeline.tests.ps1
@@ -4,8 +4,8 @@ Param()
 Import-Module $PSScriptRoot\..\Az.DevTestLabs2.psm1 -Verbose:$false
 
 $labs = @(
-    [pscustomobject]@{Name=('DtlLibrary-Vm-' + (Get-Random)); ResourceGroupName=('DtlLibrary-VmRg-' + (Get-Random)); Location='westus'},
-    [pscustomobject]@{Name=('DtlLibrary-Vm-' + (Get-Random)); ResourceGroupName=('DtlLibrary-VmRg-' + (Get-Random)); Location='eastus'}
+    [pscustomobject]@{Name=('DtlLibrary-VmPipeline-' + (Get-Random)); ResourceGroupName=('DtlLibrary-VmPipelineRg-' + (Get-Random)); Location='westus'},
+    [pscustomobject]@{Name=('DtlLibrary-VmPipeline-' + (Get-Random)); ResourceGroupName=('DtlLibrary-VmPipelineRg-' + (Get-Random)); Location='eastus'}
 )
 
 $vms = @(
@@ -25,6 +25,8 @@ Describe 'VM Management' {
 
             # Create VMs in a lab
             $createdVMs = $vms| Select-Object -Property @{N='Name'; E={$createdLabs[0].Name}}, @{N='ResourceGroupName'; E={$createdLabs[0].ResourceGroupName}}, VmName,Size,Claimable,Username,Password,OsType,Sku,Publisher,Offer | New-AzDtlVm
+            $createdVMs = Get-AzDtlVm -Lab $createdLabs[0]
+
             Write-Verbose "Created VMs:"
             $createdVMs | Out-String | Write-Verbose
             $createdVMs.Count | Should -Be 2

--- a/samples/DevTestLabs/Modules/Library/Tests/Vm-Properties.tests.ps1
+++ b/samples/DevTestLabs/Modules/Library/Tests/Vm-Properties.tests.ps1
@@ -4,7 +4,7 @@ Param()
 Import-Module $PSScriptRoot\..\Az.DevTestLabs2.psm1 -Verbose:$false
 
 $lab = @(
-    [pscustomobject]@{Name=('DtlLibrary-Vm-' + (Get-Random)); ResourceGroupName=('DtlLibrary-VmRg-' + (Get-Random)); Location='westus'}
+    [pscustomobject]@{Name=('DtlLibrary-VmProperties-' + (Get-Random)); ResourceGroupName=('DtlLibrary-VmProperties-rg-' + (Get-Random)); Location='westus'}
 )
 
 $vm = @(
@@ -21,6 +21,12 @@ Describe 'Virtual Machine Management' {
 
             # Create the lab
             $createdLab = $lab | New-AzDtlLab
+
+            Write-Verbose "Original Lab Object:"
+            $lab | Out-String | Write-Verbose
+
+            Write-Verbose "Created Lab:"
+            $createdLab | Out-String | Write-Verbose
 
             # Create a VM in the lab
             $vm | Select-Object -Property @{N='Name'; E={$createdLab.Name}}, @{N='ResourceGroupName'; E={$createdLab.ResourceGroupName}}, VmName,Size,Claimable,Username,Password,OsType,Sku,Publisher,Offer | New-AzDtlVm


### PR DESCRIPTION
We were often seeing failures from DTL Library tests running nightly.  I've been working on fixing all the little issues so we have more stable runs.  To do this:
1) All the tests need to use unique lab names & RG names - I occasionally saw collisions even though we're using Get-Random
2)  The harness (RunPesterTests) should print verbose output for each test together, easier for reviewing logs
3)  There were a few cases where we needed to switch to checking what was created in Azure where we weren't