### PR TITLE
Fix deployment error caused by the new values of the SKU of SharePoint images

### DIFF
--- a/Environments/SharePoint-AllVersions/CHANGELOG.md
+++ b/Environments/SharePoint-AllVersions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for AzureRM template SharePoint-ADFS-DevTestLabs
 
+## February 2020 update
+
+* Fix deployment error caused by the new values of the SKU of SharePoint images, which changed from '2013' / '2016' / '2019' to 'sp2013' / 'sp2016' / 'sp2019'
+* Update the schema of deploymentTemplate.json to latest version
+
 ## November 2019 update
 
 * Remove configuration of AD CS if parameter ConfigureADFS is set to No, to speed up the deployment time of the template

--- a/Environments/SharePoint-AllVersions/azuredeploy.json
+++ b/Environments/SharePoint-AllVersions/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "provisionSharePoint2019": {
@@ -291,7 +291,7 @@
     "vmSP2013": {
       "vmImagePublisher": "MicrosoftSharePoint",
       "vmImageOffer": "MicrosoftSharePointServer",
-      "vmImageSKU": "2013",
+      "vmImageSKU": "sp2013",
       "vmOSDiskName": "Disk-SP2013-OS",
       "vmVmSize": "[parameters('vmSPSize')]",
       "vmNicName": "[concat('NIC-', variables('generalSettings').vmSP2013Name, '-0')]",
@@ -302,7 +302,7 @@
     "vmSP2016": {
       "vmImagePublisher": "MicrosoftSharePoint",
       "vmImageOffer": "MicrosoftSharePointServer",
-      "vmImageSKU": "2016",
+      "vmImageSKU": "sp2016",
       "vmOSDiskName": "Disk-SP2016-OS",
       "vmVmSize": "[parameters('vmSPSize')]",
       "vmNicName": "[concat('NIC-', variables('generalSettings').vmSP2016Name, '-0')]",
@@ -313,7 +313,7 @@
     "vmSP2019": {
       "vmImagePublisher": "MicrosoftSharePoint",
       "vmImageOffer": "MicrosoftSharePointServer",
-      "vmImageSKU": "2019",
+      "vmImageSKU": "sp2019",
       "vmOSDiskName": "Disk-SP2019-OS",
       "vmVmSize": "[parameters('vmSPSize')]",
       "vmNicName": "[concat('NIC-', variables('generalSettings').vmSP2019Name, '-0')]",

--- a/Environments/SharePoint-AllVersions/metadata.json
+++ b/Environments/SharePoint-AllVersions/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template deploys SharePoint 2019, 2016 and 2013. Each SharePoint version is independent and may or may not be deployed. A DC is provisioned with ADFS and ADCS, and 1 SQL Server is provisioned for all SharePoint farms, which have a small configuration to provision quickly.",
   "summary": "This template deploys SharePoint 2019, 2016 and 2013. Each SharePoint version is independent and may or may not be deployed.",
   "githubUsername": "Yvand",
-  "dateUpdated": "2019-11-06"
+  "dateUpdated": "2020-02-26"
 }


### PR DESCRIPTION
### Changelog

* Fix deployment error caused by the new values of the SKU of SharePoint images, which changed from '2013' / '2016' / '2019' to 'sp2013' / 'sp2016' / 'sp2019'
* Update the schema of deploymentTemplate.json to latest version
