### PR TITLE
Fix DSC parameter SharePointVersion that relied on the values of SKUs of SharePoint images

### DIFF
--- a/Environments/SharePoint-AllVersions/azuredeploy.json
+++ b/Environments/SharePoint-AllVersions/azuredeploy.json
@@ -870,7 +870,7 @@
             "DCName": "[variables('generalSettings').vmDCName]",
             "SQLName": "[variables('generalSettings').vmSQLName]",
             "SQLAlias": "[variables('generalSettings').sqlAlias]",
-            "SharePointVersion": "[variables('vmSP2013').vmImageSKU]",
+            "SharePointVersion": "2013",
             "ConfigureADFS": "[if(equals(parameters('configureADFS'), 'Yes'), 1, 0)]"
           },
           "privacy": {
@@ -1039,7 +1039,7 @@
             "DCName": "[variables('generalSettings').vmDCName]",
             "SQLName": "[variables('generalSettings').vmSQLName]",
             "SQLAlias": "[variables('generalSettings').sqlAlias]",
-            "SharePointVersion": "[variables('vmSP2016').vmImageSKU]",
+            "SharePointVersion": "2016",
             "ConfigureADFS": "[if(equals(parameters('configureADFS'), 'Yes'), 1, 0)]"
           },
           "privacy": {
@@ -1208,7 +1208,7 @@
             "DCName": "[variables('generalSettings').vmDCName]",
             "SQLName": "[variables('generalSettings').vmSQLName]",
             "SQLAlias": "[variables('generalSettings').sqlAlias]",
-            "SharePointVersion": "[variables('vmSP2019').vmImageSKU]",
+            "SharePointVersion": "2019",
             "ConfigureADFS": "[if(equals(parameters('configureADFS'), 'Yes'), 1, 0)]"
           },
           "privacy": {


### PR DESCRIPTION
### Changelog

* Use hardcoded values for DSC parameter SharePointVersion as it expects "2013", "2016" or "2019", which no longer match the values used for the SKU of SharePoint images

@leovms I submitted previous PR without thoroughly testing it, sorry for that.
This time I tested a full deployment and this PR is safe to approve.
