### PR TITLE
Update size of VMs in template SharePoint-AllVersions

### DIFF
--- a/Environments/SharePoint-AllVersions/CHANGELOG.md
+++ b/Environments/SharePoint-AllVersions/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for AzureRM template SharePoint-ADFS-DevTestLabs
 
+## August 2020 update
+
+* Update VM sizes to more recent, powerful and cheaper ones (prices per month in West US as of 2020-08-11):
+  - DC: from [Standard_F4](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-previous-gen?toc=/azure/virtual-machines/linux/toc.json&bc=/azure/virtual-machines/linux/breadcrumb/toc.json) ($316.09) to [Standard_DS2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) ($183.96)
+  - SQL: from [Standard_D2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) ($183.96) to [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) ($169.36)
+  - SPL: from [Standard_D11_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series-memory) ($192.72) to [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) ($169.36)
+
 ## July 2020 update
 
 * Update SQL to SQL Server 2019 on Windows Server 2019

--- a/Environments/SharePoint-AllVersions/CHANGELOG.md
+++ b/Environments/SharePoint-AllVersions/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Update VM sizes to more recent, powerful and cheaper ones (prices per month in West US as of 2020-08-11):
   - DC: from [Standard_F4](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-previous-gen?toc=/azure/virtual-machines/linux/toc.json&bc=/azure/virtual-machines/linux/breadcrumb/toc.json) ($316.09) to [Standard_DS2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) ($183.96)
-  - SQL: from [Standard_D2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) ($183.96) to [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) ($169.36)
-  - SP: from [Standard_D11_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series-memory) ($192.72) to [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) ($169.36)
+  - SQL: from [Standard_D2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) ($183.96) to [Standard_E2ds_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/edv4-edsv4-series) ($185.42)
+  - SP: from [Standard_D11_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series-memory) ($192.72) to [Standard_E2ds_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/edv4-edsv4-series) ($185.42)
 
 ## July 2020 update
 

--- a/Environments/SharePoint-AllVersions/CHANGELOG.md
+++ b/Environments/SharePoint-AllVersions/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Update VM sizes to more recent, powerful and cheaper ones (prices per month in West US as of 2020-08-11):
   - DC: from [Standard_F4](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-previous-gen?toc=/azure/virtual-machines/linux/toc.json&bc=/azure/virtual-machines/linux/breadcrumb/toc.json) ($316.09) to [Standard_DS2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) ($183.96)
   - SQL: from [Standard_D2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) ($183.96) to [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) ($169.36)
-  - SPL: from [Standard_D11_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series-memory) ($192.72) to [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) ($169.36)
+  - SP: from [Standard_D11_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series-memory) ($192.72) to [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) ($169.36)
 
 ## July 2020 update
 

--- a/Environments/SharePoint-AllVersions/README.md
+++ b/Environments/SharePoint-AllVersions/README.md
@@ -1,29 +1,26 @@
 # Azure template for SharePoint 2019 / 2016 / 2013, optimized for DevTest Labs
 
-This template deploys SharePoint 2019, 2016 and 2013. Each SharePoint version is independent and may or may not be deployed, depending on your needs.  
-A DC is provisioned and configured with ADFS (optional) and ADCS, and a unique SQL Server is provisioned for all SharePoint farms.  
-Each SharePoint farm has 1 web application created with 2 zones: Windows NTLM on Default zone and ADFS on Intranet zone (optional). They have a minimum configuration to provision quickly.
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FEnvironments%2FSharePoint-AllVersions%2Fazuredeploy.json)
+[![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FEnvironments%2FSharePoint-AllVersions%2Fazuredeploy.json)
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FEnvironments%2FSharePoint-AllVersions%2Fazuredeploy.json)
 
-All subnets connected to a virtual machine are protected by a Network Security Group. You can connect to virtual machines using:
+This template deploys SharePoint 2019, 2016 and 2013. Each SharePoint version is independent and may or may not be deployed, depending on your needs.  
+A DC is provisioned and configured with ADFS and ADCS (both are optional), and a unique SQL Server is provisioned for all SharePoint farms.  
+Each SharePoint farm a lightweight configuration to provision quickly: 1 web application with 1 site collection, using Windows NTLM on Default zone, and optionally ADFS on Intranet zone.
+
+All subnets are protected by a Network Security Group with rules that restrict network access. You can connect to virtual machines using:
 
 * [Azure Bastion](https://azure.microsoft.com/en-us/services/azure-bastion/) if you set parameter addAzureBastion to 'Yes'.
 * RDP protocol if you set parameter addPublicIPToVMs to 'Yes'. Each machine will have a public IP, a DNS name, and the TCP port 3389 will be allowed from Internet.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FEnvironments%2FSharePoint-AllVersions%2Fazuredeploy.json" target="_blank">
-    <img src="http://azuredeploy.net/deploybutton.png"/>
-</a>
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-devtestlab%2Fmaster%2FEnvironments%2FSharePoint-ADFS%2Fazuredeploy.json" target="_blank">
-    <img src="http://armviz.io/visualizebutton.png"/>
-</a>
-
 By default, virtual machines use standard storage and are sized with a good balance between cost and performance:
 
-* Virtual machine running the Domain Controller: [Standard_F4](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-compute#fsv2-series-sup1sup) / Standard_LRS
-* Virtual machine running SQL Server: [Standard_D2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-general#dv2-series) / Standard_LRS
-* Virtual machine(s) running SharePoint: [Standard_D11_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-memory#dv2-series-11-15) / Standard_LRS
+* Virtual machine size for DC: [Standard_DS2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) / Standard_LRS (2 CPU / 7 GiB RAM)
+* Virtual machine size for SQL Server: [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) / Standard_LRS (2 CPU / 16 GiB RAM)
+* Virtual machine size for SharePoint: [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) / Standard_LRS (2 CPU / 16 GiB RAM)
 
 If you wish to get better performance, I recommended the following sizes / storage account types:
 
-* Virtual machine running the Domain Controller: [Standard_F4](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-compute#fsv2-series-sup1sup) / Standard_LRS
-* Virtual machine running SQL Server: [Standard_DS2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-general#dsv2-series) / Premium_LRS
-* Virtual machine(s) running SharePoint: [Standard_DS3_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-general#dsv2-series) / Premium_LRS
+* Virtual machine size for DC: [Standard_DS2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) / Standard_LRS
+* Virtual machine size for SQL Server: [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) / Premium_LRS (2 CPU / 16 GiB RAM)
+* Virtual machine size for SharePoint: [Standard_E4as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) / Premium_LRS (4 CPU / 32 GiB RAM)

--- a/Environments/SharePoint-AllVersions/README.md
+++ b/Environments/SharePoint-AllVersions/README.md
@@ -6,7 +6,7 @@
 
 This template deploys SharePoint 2019, 2016 and 2013. Each SharePoint version is independent and may or may not be deployed, depending on your needs.  
 A DC is provisioned and configured with ADFS and ADCS (both are optional), and a unique SQL Server is provisioned for all SharePoint farms.  
-Each SharePoint farm a lightweight configuration to provision quickly: 1 web application with 1 site collection, using Windows NTLM on Default zone, and optionally ADFS on Intranet zone.
+Each SharePoint farm has a lightweight configuration to provision quickly: 1 web application with 1 site collection, using Windows NTLM on Default zone, and optionally ADFS on Intranet zone.
 
 All subnets are protected by a Network Security Group with rules that restrict network access. You can connect to virtual machines using:
 
@@ -16,8 +16,8 @@ All subnets are protected by a Network Security Group with rules that restrict n
 By default, virtual machines use standard storage and are sized with a good balance between cost and performance:
 
 * Virtual machine size for DC: [Standard_DS2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) / Standard_LRS (2 CPU / 7 GiB RAM)
-* Virtual machine size for SQL Server: [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) / Standard_LRS (2 CPU / 16 GiB RAM)
-* Virtual machine size for SharePoint: [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) / Standard_LRS (2 CPU / 16 GiB RAM)
+* Virtual machine size for SQL Server: [Standard_E2ds_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/edv4-edsv4-series) / Standard_LRS (2 CPU / 16 GiB RAM)
+* Virtual machine size for SharePoint: [Standard_E2ds_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/edv4-edsv4-series) / Standard_LRS (2 CPU / 16 GiB RAM)
 
 If you wish to get better performance, I recommended the following sizes / storage account types:
 

--- a/Environments/SharePoint-AllVersions/azuredeploy.json
+++ b/Environments/SharePoint-AllVersions/azuredeploy.json
@@ -103,7 +103,7 @@
     },
     "vmSQLSize": {
       "type": "string",
-      "defaultValue": "Standard_E2as_v4",
+      "defaultValue": "Standard_E2ds_v4",
       "metadata": {
         "description": "Size of the SQL VM"
       }
@@ -122,7 +122,7 @@
     },
     "vmSPSize": {
       "type": "string",
-      "defaultValue": "Standard_E2as_v4",
+      "defaultValue": "Standard_E2ds_v4",
       "metadata": {
         "description": "Size of the SharePoint VM"
       }

--- a/Environments/SharePoint-AllVersions/azuredeploy.json
+++ b/Environments/SharePoint-AllVersions/azuredeploy.json
@@ -84,7 +84,7 @@
     },
     "vmDCSize": {
       "type": "string",
-      "defaultValue": "Standard_F4",
+      "defaultValue": "Standard_DS2_v2",
       "metadata": {
         "description": "Size of the DC VM"
       }
@@ -103,7 +103,7 @@
     },
     "vmSQLSize": {
       "type": "string",
-      "defaultValue": "Standard_D2_v2",
+      "defaultValue": "Standard_E2as_v4",
       "metadata": {
         "description": "Size of the SQL VM"
       }
@@ -122,7 +122,7 @@
     },
     "vmSPSize": {
       "type": "string",
-      "defaultValue": "Standard_D11_v2",
+      "defaultValue": "Standard_E2as_v4",
       "metadata": {
         "description": "Size of the SharePoint VM"
       }

--- a/Environments/SharePoint-AllVersions/metadata.json
+++ b/Environments/SharePoint-AllVersions/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template deploys SharePoint 2019, 2016 and 2013. Each SharePoint version is independent and may or may not be deployed. A DC is provisioned with ADFS and ADCS, and 1 SQL Server is provisioned for all SharePoint farms, which have a small configuration to provision quickly.",
   "summary": "This template deploys SharePoint 2019, 2016 and 2013. Each SharePoint version is independent and may or may not be deployed.",
   "githubUsername": "Yvand",
-  "dateUpdated": "2020-07-23"
+  "dateUpdated": "2020-08-11"
 }


### PR DESCRIPTION
## Description

As I've been deploying the template a lot recently, I realized the sizes were outdated.
I took the time to look for better ones, and the only technical change in this PR is a new default size for the VMs

## Changelog

* Update VM sizes to more recent, powerful and cheaper ones (prices per month in West US as of 2020-08-11):
  - DC: from [Standard_F4](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-previous-gen?toc=/azure/virtual-machines/linux/toc.json&bc=/azure/virtual-machines/linux/breadcrumb/toc.json) ($316.09) to [Standard_DS2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) ($183.96)
  - SQL: from [Standard_D2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series) ($183.96) to [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) ($169.36)
  - SP: from [Standard_D11_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series-memory) ($192.72) to [Standard_E2as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) ($169.36)
* Update README
