### PR TITLE
Revert SP and SQL to old VM sizes

### DIFF
--- a/Environments/SharePoint-AllVersions/CHANGELOG.md
+++ b/Environments/SharePoint-AllVersions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for AzureRM template SharePoint-ADFS-DevTestLabs
 
+## August 2020-08-18 update
+
+* Revert SP and SQL to old VM sizes due to issues with Edsv4-series in "East US" since today (they fail to start)
+
 ## August 2020 update 3
 
 * Update DSC configuration of all VMs to make deployment much more reliable after the change to fix the time out issue

--- a/Environments/SharePoint-AllVersions/azuredeploy.json
+++ b/Environments/SharePoint-AllVersions/azuredeploy.json
@@ -103,7 +103,7 @@
     },
     "vmSQLSize": {
       "type": "string",
-      "defaultValue": "Standard_E2ds_v4",
+      "defaultValue": "Standard_D2_v2",
       "metadata": {
         "description": "Size of the SQL VM"
       }
@@ -122,7 +122,7 @@
     },
     "vmSPSize": {
       "type": "string",
-      "defaultValue": "Standard_E2ds_v4",
+      "defaultValue": "Standard_D11_v2",
       "metadata": {
         "description": "Size of the SharePoint VM"
       }

--- a/Environments/SharePoint-AllVersions/metadata.json
+++ b/Environments/SharePoint-AllVersions/metadata.json
@@ -3,5 +3,5 @@
   "description": "SharePoint 2019 / 2016 / 2013 with a lightweight configuration. Each version is independent and may or may not be deployed.",
   "summary": "SharePoint 2019 / 2016 / 2013 with a lightweight configuration. Each version is independent and may or may not be deployed.",
   "githubUsername": "Yvand",
-  "dateUpdated": "2020-08-17"
+  "dateUpdated": "2020-08-18"
 }


### PR DESCRIPTION
Since today, all [Edsv4-series](https://docs.microsoft.com/en-us/azure/virtual-machines/edv4-edsv4-series) VMs fail to start in region "East US", which impacts SharePoint template since it's used for SP and SQL VMs.
So I revert SP and SQL to their old VM size as a workaround.