### PR TITLE
Update CloneGitRepo to not fail the artifact

### DIFF
--- a/Artifacts/windows-clone-git-repo/GitEnlister.ps1
+++ b/Artifacts/windows-clone-git-repo/GitEnlister.ps1
@@ -418,10 +418,10 @@ function CloneGitRepo
     WriteLog $($gitExeLocation + " " + $args)
 
     # Run the git clone operation
-    $p = Start-Process -FilePath $gitExeLocation -ArgumentList $args -RedirectStandardOutput $stdOutLogfile -RedirectStandardError $stdErrLogfile -PassThru -Wait
+    & cmd /c "git $args 2>&1"
 
     # Was the clone operation successful?
-    if ($p.ExitCode -ne 0)
+    if ($LASTEXITCODE -ne 0)
     {
         $errMsg = $("Error! Git clone failed with exit code " + $p.ExitCode + ". Please see the log file: " + $stdErrLogfile)
         WriteLog $errMsg


### PR DESCRIPTION
This change updates the way the artifact calls into git as to prevent it from sending any output to stderr. This will ensure the artifact will not error-out due to the peculiarities in powershell's remote session error handling.