### PR TITLE
Fix metadata file to make template actually visible

### DIFF
--- a/Environments/SharePoint-SingleFarm-FullConfig/metadata.json
+++ b/Environments/SharePoint-SingleFarm-FullConfig/metadata.json
@@ -1,6 +1,4 @@
 {
-  "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
-  "type": "QuickStart",
   "itemDisplayName": "Single SharePoint farm with extensive configuration",
   "summary": "This template configures SharePoint with 1 web application (Windows + ADFS), some path based / host-named site collections, and UPA + Apps (add-ins) services. Claims provider LDAPCP is installed.",
   "description": "A single SharePoint 2019 / 2016 / 2013 farm with an extensive configuration to ease the creation of complex environments.",


### PR DESCRIPTION
## Changelog

New SharePoint template is not visible in the list, when adding a lab.
I assume it's because the metadata file contains lines that are not valid in DTL so I remove them here

Note: but the template is visible when I reference my private repository in DTL, so I'm not sure it's the actual cause
