### PR TITLE
Fix documentation link for 'PowerShell on Linux' artifact

### DIFF
--- a/Artifacts/linux-powershell/Artifactfile.json
+++ b/Artifacts/linux-powershell/Artifactfile.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
     "title": "PowerShell on Linux",
     "description": "Installs PowerShell on Linux either on CentOS 7 or Ubuntu 14.04 or 16.04 LTS.",
-    "publisher": "PowerShell Magazine",    
+    "publisher": "PowerShell Magazine",
     "tags": [
         "powershell",
         "Linux"
@@ -14,7 +14,7 @@
             "type": "string",
             "displayName": "Package URL",
             "allowEmpty": false,
-            "description": "The PowerShell on Linux package URL based on the distribution type. The supported list of distributions and URLs are available at https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md"
+            "description": "The PowerShell on Linux package URL based on the distribution type. The supported list of distributions and URLs are available at https://github.com/PowerShell/PowerShell#get-powershell"
         }
     },
     "runCommand": {


### PR DESCRIPTION
The link documenting the supported linux distributions returns a 404 as the link has moved.