### PR TITLE
Added EnableGPUDriver param

### DIFF
--- a/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
+++ b/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
@@ -649,6 +649,10 @@ function New-AzLab {
         [parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "Size for template VM")]
         [ValidateNotNullOrEmpty()]
         $Size,
+            
+        [parameter(mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $InstallGpuDriverEnabled = $false,
 
         [parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, HelpMessage = "User name if shared password is enabled")]
         [string]
@@ -669,6 +673,7 @@ function New-AzLab {
         [parameter(mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [switch]
         $SharedPasswordEnabled = $false,
+
         [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Idle Shutdown Grace Period (0 is off)")]
         [int]
         $idleGracePeriod = 15,
@@ -697,6 +702,7 @@ function New-AzLab {
                 $sharedPassword = if ($SharedPasswordEnabled) { "Enabled" } else { "Disabled" }
                 $imageType = if ($image.id -match '/galleryimages/') { 'galleryImageResourceId' } else { 'sharedImageResourceId' }
                 if ($LinuxRdpEnabled) {$linuxRdpState = 'Enabled'} else { $linuxRdpState = 'Disabled' }
+                if ($InstallGpuDriverEnabled) {$gpuDriverState = 'Enabled'} else { $gpuDriverState = 'Disabled' }
                 if ($SkipTemplateCreation) {$hasTemplateVm = 'Disabled' } else { $hasTemplateVm = 'Enabled' }
                 if ($idleGracePeriod -eq 0) {$idleShutdownMode = "None"} else {$idleShutdownMode = "OnDisconnect"}
                 if ($idleOsGracePeriod -eq 0) {$enableDisconnectOnIdle = "Disabled"} else {$enableDisconnectOnIdle = "Enabled"}
@@ -714,7 +720,7 @@ function New-AzLab {
                             vmSize = $Size
                             sharedPasswordState = $sharedPassword
                             templateVmState = $hasTemplateVm
-                            
+                            installGpuDriverEnabled = $gpuDriverState
                         }
                     } | ConvertTo-Json) | Out-Null
                 } else {
@@ -736,6 +742,7 @@ function New-AzLab {
                             idleOsGracePeriod = "PT$($idleOsGracePeriod.ToString())M"
                             enableNoConnectShutdown = $enableNoConnectShutdown
                             idleNoConnectGracePeriod = "PT$($idleNoConnectGracePeriod.ToString())M"
+                            installGpuDriverEnabled = $gpuDriverState
                         }
                     } | ConvertTo-Json) | Out-Null
                 }


### PR DESCRIPTION
We need to add a parameter to both the Az.LabServices.psm1 and the LabCreator.ps1 file that allows the GPU Drivers to be installed when creating a lab that uses GPU VM size.  Note that Minneapolis encountered this issue because the labs that we set up for their first semester required that their students manually install their GPU drivers.  For second semester, we need to address this.

As part of this PR, I also made the following changes to fix a few errors that I ran into.  I am using version 7.1 of Powershell - not sure if the version that I'm using introduced these issues:

1.) LabCreator.psm1 - line 125 - I was getting an error because the Count property wasn't recognized in the case that only a single image was returned.  I fixed this by added the '@' symbol to force the results to an array.

2.) LabCreator.psm1 - line 196 - I was getting an error saying that a positional parameter cannot be found that accepts argument 'Az.LabServices.psm1'.  I fixed this by changing the path joins to only use two parameters.  