### PR TITLE
Added GPU template VM restart and misc fixes

### DIFF
--- a/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
+++ b/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
@@ -885,7 +885,7 @@ function New-AzLab {
 
                     # The template VM needs to be restarted for the GPU drivers to finish installing properly
                     # This will eventually be done within the product, but for now, we need to do this explicitly
-                    Write-Verbose "Start template VM"
+                    Write-Verbose "Start template VM after installing GPU drivers"
                     Get-AzLabTemplateVm $lab | Start-AzLabTemplateVm
                     Get-AzLabTemplateVm $lab | Stop-AzLabTemplateVm
                     Write-Verbose "Stopped template VM"

--- a/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
+++ b/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
@@ -917,9 +917,9 @@ function Set-AzLab {
         [string]
         $UserAccessMode,
 
-        [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]       
+        [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [ValidateSet('Enabled', 'Disabled')]
-         [string]
+        [string]
         $SharedPasswordEnabled,
 
         [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Quota of hours x users (defaults to 40)")]


### PR DESCRIPTION
When GPU drivers are installed, I added an automatic restart of the template VM.  For the GPU drivers to properly install, the machine must be restarted afterwards.  The product should actually ensure that the template VM is restarted - however, it's rare that users run into this in the UI because they typically start the template VM at least once before publishing.

While adding this, I also ran across a few other bugs in the script which I fixed in this PR:
1.) The LinuxRdp property wasn't working because we had a mismatch in naming - we expected the .csv column to be named "LinuxRdp" but the New-AzLab function expected it to be "LinuxRdpEnabled".
2.) Same issue as mentioned in the above bullet, also existed for the GpuDriverEnabled properly.
3.) The SharedPassword property didn't work in the case that you had an existing lab that it was attempting to call Set-AzLab with.  This is because of an inconsistency issue with SharePassword expecting Enabled\Disabled instead of true\false.  Also, there is a naming consistency issue with this property.  Refer to the comments in the code for more info.
4.) My .csv file structure failed because it didn't included several columns which shouldn't be required.  I changed the import csv function to default these unrequired columns to empty values where needed.
  