### PR TITLE
[Lab Services Library] Update defaults to disable idle settings if not specified

### DIFF
--- a/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
+++ b/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
@@ -803,7 +803,7 @@ function New-AzLab {
 
         [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Idle Shutdown Grace Period (0 is off)")]
         [int]
-        $idleGracePeriod = 15,
+        $idleGracePeriod = 0,
 
         [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Disconnect on Idle Grace Period (0 is off)")]
         [int]
@@ -811,7 +811,7 @@ function New-AzLab {
 
         [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Shutdown on No Connect Grace Period (0 is off)")]
         [int]
-        $idleNoConnectGracePeriod = 15,
+        $idleNoConnectGracePeriod = 0,
         
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, HelpMessage = "Enabled AAD connected labs.  NOTE:  If this Id is a teams team than the lab will be marked as a teams lab.")]
         [string] $AadGroupId,


### PR DESCRIPTION
We had a customer not able to use the library because we were defaulting idle settings to 'ON' and they were trying to use a linux distribution (CentOS 8) which isn't supported for idle settings.

We should probably default to idle settings being off in the base case for New-AzLab.