### PR TITLE
Adding deallocate & waitForShutdown to postDeployActions

### DIFF
--- a/Artifacts/linux-install-mongodb/Artifactfile.json
+++ b/Artifacts/linux-install-mongodb/Artifactfile.json
@@ -14,6 +14,12 @@
     },
     "postDeployActions": [
         {
+            "action": "deallocate"
+        },
+        {
+            "action": "waitForShutdown"
+        },
+        {
             "action": "restart"
         }
     ]

--- a/Artifacts/windows-CreateDomain/artifactfile.json
+++ b/Artifacts/windows-CreateDomain/artifactfile.json
@@ -37,6 +37,12 @@
   },
   "postDeployActions": [
     {
+      "action": "deallocate"
+    },
+    {
+      "action": "waitForShutdown"
+    },
+    {
       "action": "restart"
     }
   ]

--- a/Artifacts/windows-ServiceFabricSDK/artifactfile.json
+++ b/Artifacts/windows-ServiceFabricSDK/artifactfile.json
@@ -28,6 +28,12 @@
   },
   "postDeployActions": [
     {
+      "action": "deallocate"
+    },
+    {
+      "action": "waitForShutdown"
+    },
+    {
       "action": "restart"
     }
   ]

--- a/Artifacts/windows-docker/Artifactfile.json
+++ b/Artifacts/windows-docker/Artifactfile.json
@@ -15,6 +15,12 @@
     },
     "postDeployActions": [
         {
+            "action": "deallocate"
+        },
+        {
+            "action": "waitForShutdown"
+        },
+        {
             "action": "restart"
         }
     ]

--- a/Artifacts/windows-domain-join-new/Artifactfile.json
+++ b/Artifacts/windows-domain-join-new/Artifactfile.json
@@ -37,6 +37,12 @@
   },
   "postDeployActions": [
     {
+      "action": "deallocate"
+    },
+    {
+      "action": "waitForShutdown"
+    },
+    {
       "action": "restart"
     }
   ]

--- a/Artifacts/windows-jhipster/Artifactfile.json
+++ b/Artifacts/windows-jhipster/Artifactfile.json
@@ -14,6 +14,12 @@
     },
     "postDeployActions": [
         {
+            "action": "deallocate"
+        },
+        {
+            "action": "waitForShutdown"
+        },
+        {
             "action": "restart"
         }
     ]

--- a/Artifacts/windows-powershell3/Artifactfile.json
+++ b/Artifacts/windows-powershell3/Artifactfile.json
@@ -14,6 +14,12 @@
     },
     "postDeployActions": [
         {
+            "action": "deallocate"
+        },
+        {
+            "action": "waitForShutdown"
+        },
+        {
             "action": "restart",
             "delayStart": 60
         }

--- a/Artifacts/windows-visualstudio/Artifactfile.json
+++ b/Artifacts/windows-visualstudio/Artifactfile.json
@@ -42,6 +42,12 @@
   },
   "postDeployActions": [
     {
+      "action": "deallocate"
+    },
+    {
+      "action": "waitForShutdown"
+    },
+    {
       "action": "restart"
     }
   ]

--- a/Artifacts/windows-vsts-build-agent/Artifactfile.json
+++ b/Artifacts/windows-vsts-build-agent/Artifactfile.json
@@ -88,6 +88,12 @@
   },
   "postDeployActions": [
     {
+      "action": "deallocate"
+    },
+    {
+      "action": "waitForShutdown"
+    },
+    {
       "action": "restart"
     }
   ]

--- a/Artifacts/windows-webdeploy/Artifactfile.json
+++ b/Artifacts/windows-webdeploy/Artifactfile.json
@@ -13,6 +13,12 @@
   },
   "postDeployActions": [
     {
+      "action": "deallocate"
+    },
+    {
+      "action": "waitForShutdown"
+    },
+    {
       "action": "restart"
     }
   ]

--- a/Artifacts/windows-wsl/Artifactfile.json
+++ b/Artifacts/windows-wsl/Artifactfile.json
@@ -13,6 +13,13 @@
     },
     "postDeployActions": [
         {
-          "action": "restart"
-        }]
+            "action": "deallocate"
+        },
+        {
+            "action": "waitForShutdown"
+        },
+        {
+            "action": "restart"
+        }
+    ]
 }


### PR DESCRIPTION
As a result of a Compute fix that is rolling out but has no ETA, we need to get around restart issue by ensuring a full shutdown/restart cycle, as needed.