### PR TITLE
Installing updates for all Microsoft products

### DIFF
--- a/Artifacts/windows-install-windows-updates/Artifactfile.json
+++ b/Artifacts/windows-install-windows-updates/Artifactfile.json
@@ -7,7 +7,16 @@
     "Windows"
   ],
   "targetOsType": "Windows",
+  "parameters": {
+    "includeMicrosoftUpdates": {
+      "type": "bool",
+      "displayName": "Include Microsoft updates",
+      "description": "Include updates for all Microsoft products",
+      "defaultValue": false,
+      "allowEmpty": true
+    }
+  },
   "runCommand": {
-    "commandToExecute": "powershell.exe -ExecutionPolicy bypass \"& ./artifact.ps1\""
+    "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./artifact.ps1 -IncludeMicrosoftUpdates:$', parameters('includeMicrosoftUpdates'), '\"')]"
   }
 }

--- a/Artifacts/windows-install-windows-updates/artifact.ps1
+++ b/Artifacts/windows-install-windows-updates/artifact.ps1
@@ -3,6 +3,12 @@
 # PowerShell configurations
 #
 
+
+[CmdletBinding()]
+param(
+    [switch] $IncludeMicrosoftUpdates
+)
+
 # NOTE: Because the $ErrorActionPreference is "Stop", this script will stop on first failure.
 #       This is necessary to ensure we capture errors inside the try-catch-finally block.
 $ErrorActionPreference = "Stop"
@@ -80,7 +86,7 @@ try
     Import-Module PSWindowsUpdate
     
     Write-Host 'Installing Windows Updates.'
-    Get-WUInstall -IgnoreUserInput -Acceptall -Download -Install -Verbose -IgnoreReboot
+    Get-WUInstall -IgnoreUserInput -Acceptall -Download -Install -Verbose -IgnoreReboot -MicrosoftUpdate:$IncludeMicrosoftUpdates
     
     Write-Host "Windows Update finished. Rebooting..."
     Write-Host "`nThe artifact was applied successfully.`n"


### PR DESCRIPTION
Update windows-install-windows-updates artifact to enable installing updates for all Microsoft products, not only Windows. 
