### PR TITLE
Add Visual Studio Code 64-bit Artifact

### DIFF
--- a/Artifacts/windows-vscode/Artifactfile.json
+++ b/Artifacts/windows-vscode/Artifactfile.json
@@ -1,13 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
-  "title": "Visual Studio Code",
+  "title": "Visual Studio Code (32-bit)",
   "publisher": "rchaganti",
-  "description": "Installs the latest stable version of Visual Studio Code.",
-  "tags": [
-    "Windows",
-    "VSCode",
-    "Visual Studio"
-  ],
+  "description": "[Obsolete] Kept for backward compatibility. Use Visual Studio Code (64-bit) for new labs.",
+  "tags": ["Windows", "VSCode", "Visual Studio"],
   "iconUri": "https://github.com/Azure/azure-devtestlab/raw/master/Artifacts/windows-vscode/vscode.png",
   "targetOsType": "Windows",
   "runCommand": {

--- a/Artifacts/windows-vscode64/Artifactfile.json
+++ b/Artifacts/windows-vscode64/Artifactfile.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
+  "title": "Visual Studio Code (64-bit)",
+  "publisher": "Eric Cote",
+  "description": "Installs the latest stable version of Visual Studio Code.",
+  "tags": ["Windows", "VSCode", "Visual Studio"],
+  "iconUri": "https://github.com/Azure/azure-devtestlab/raw/master/Artifacts/windows-vscode64/vscode.svg",
+  "targetOsType": "Windows",
+  "parameters": {
+    "Architecture": {
+      "type": "string",
+      "displayName": "Architecture",
+      "description": "Architecture of Visual Studio Code to install. Valid values are 32-bit or 64-bit. Defaults to 64-bit.",
+      "defaultValue": "64-bit",
+      "allowedValues": ["32-bit", "64-bit"]
+    },
+    "DesktopIcon": {
+      "type": "bool",
+      "displayName": "Icon on Desktop",
+      "description": "Shows VS Code icon on the Desktop",
+      "defaultValue": false
+    }
+  },
+  "runCommand": {
+    "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./install-vscode.ps1 -Architecture ', parameters('Architecture'), ' -DesktopIcon:$', parameters('DesktopIcon'), ' \"' )]"
+  }
+}

--- a/Artifacts/windows-vscode64/install-vscode.ps1
+++ b/Artifacts/windows-vscode64/install-vscode.ps1
@@ -1,0 +1,129 @@
+﻿[CmdletBinding()]
+param(
+    [ValidateSet("32-bit","64-bit")] 
+    [string] $Architecture = '64-bit',
+    [switch] $DesktopIcon
+)
+
+###################################################################################################
+#
+# PowerShell configurations
+#
+
+# NOTE: Because the $ErrorActionPreference is "Stop", this script will stop on first failure.
+#       This is necessary to ensure we capture errors inside the try-catch-finally block.
+$ErrorActionPreference = "Stop"
+
+# Hide any progress bars, due to downloads and installs of remote components.
+$ProgressPreference = "SilentlyContinue"
+
+# Ensure we force use of TLS 1.2 for all downloads.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# Discard any collected errors from a previous execution.
+$Error.Clear()
+
+# Allow certian operations, like downloading files, to execute.
+Set-ExecutionPolicy Bypass -Scope Process -Force
+
+###################################################################################################
+#
+# Handle all errors in this script.
+#
+
+trap
+{
+    # NOTE: This trap will handle all errors. There should be no need to use a catch below in this
+    #       script, unless you want to ignore a specific error.
+    $message = $Error[0].Exception.Message
+    if ($message)
+    {
+        Write-Host -Object "`nERROR: $message" -ForegroundColor Red
+    }
+
+    Write-Host "`nThe artifact failed to apply.`n"
+
+    # IMPORTANT NOTE: Throwing a terminating error (using $ErrorActionPreference = "Stop") still
+    # returns exit code zero from the PowerShell script when using -File. The workaround is to
+    # NOT use -File when calling this script and leverage the try-catch-finally block and return
+    # a non-zero exit code from the catch block.
+    exit -1
+}
+
+###################################################################################################
+#
+# Functions used in this script.
+#
+
+
+function Get-VSCodeSetup
+{
+    [CmdletBinding()]
+    param(
+        [string] $SetupExe,
+        [ValidateSet("32-bit","64-bit")] 
+        [string] $Architecture
+    )
+
+    $url=''
+
+    switch ($Architecture)
+    {
+        '32-bit' { $url = 'https://update.code.visualstudio.com/latest/win32/stable' }
+        '64-bit' { $url = 'https://update.code.visualstudio.com/latest/win32-x64/stable' }
+    }
+
+
+    Invoke-WebRequest -Uri $url -OutFile $SetupExe -UseBasicParsing
+}
+
+###################################################################################################
+#
+# Main execution block.
+#
+
+Write-Host "Preparing to install the latest version of Visual Studio Code ($Architecture)."
+$setupExe = Join-Path $PSScriptRoot 'vscodesetup.exe'
+$setupLog = Join-Path $PSScriptRoot 'vscodesetup.log'
+$setupExe = Join-Path $env:temp 'vscodesetup.exe'
+$setupLog = Join-Path $env:temp 'vscodesetup.log'
+
+try
+{
+    Push-Location $PSScriptRoot
+
+    Write-Host "Downloading Visual Studio Code ($Architecture) installer."
+    Get-VSCodeSetup -SetupExe  $SetupExe -Architecture $Architecture
+    
+
+    # Switches documentation: (https://jrsoftware.org/ishelp/)
+    # /SP-: Disables the 'This will install VS Code. Do you wish to continue?' prompt 
+    #       at the beginning of Setup.
+    # /SUPPRESSMSGBOXES: Suppress message boxes, use defaults. (Folder location, 
+    #                    language, tasks, etc.)
+    # /VERYSILENT: Progress window is not displayed.
+    # /NORESTART: Prevents Setup from restarting the system, after a successful installation
+    # /LOG: Creates a log file
+    # /MERGETASKS: Specifies a comma-separated list of tasks and merges it with the default
+
+    #     Here is the full list of tasks available in VSCode (*=default):
+    #     desktopicon -- Creates a desktop icon
+    #     quicklaunchicon -- Creates a quick launch shortcut (Windows XP only)
+    #     addcontextmenufiles -- Right click open menu for files in explorer.exe
+    #     addcontextmenufolders -- Right click open menu for folders in explorer.exe
+    #     *associatewithfiles -- Associates hundreds of file extensions to VsCode.exe
+    #     *addtopath -- Adds the vscode folder in the path environment variable
+    #     *runcode -- Runs the vscode after interactive setup. Ignored when install is silent
+    
+    $desk = if ($DesktopIcon) {'desktopicon,'} else {''};
+    $tasks= $desk + "addcontextmenufiles,addcontextmenufolders";
+
+    Write-Host "Installing Visual Studio Code ($Architecture)."
+    & "$setupExe" /SP- /SUPPRESSMSGBOXES /VERYSILENT /NORESTART /LOG="$setupLog" /MERGETASKS="$tasks" | Out-Default
+
+    Write-Host "`nThe artifact was applied successfully.`n"
+}
+finally
+{
+    Pop-Location
+}

--- a/Artifacts/windows-vscode64/vscode.svg
+++ b/Artifacts/windows-vscode64/vscode.svg
@@ -1,0 +1,41 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M70.9119 99.3171C72.4869 99.9307 74.2828 99.8914 75.8725 99.1264L96.4608 89.2197C98.6242 88.1787 100 85.9892 100 83.5872V16.4133C100 14.0113 98.6243 11.8218 96.4609 10.7808L75.8725 0.873756C73.7862 -0.130129 71.3446 0.11576 69.5135 1.44695C69.252 1.63711 69.0028 1.84943 68.769 2.08341L29.3551 38.0415L12.1872 25.0096C10.589 23.7965 8.35363 23.8959 6.86933 25.2461L1.36303 30.2549C-0.452552 31.9064 -0.454633 34.7627 1.35853 36.417L16.2471 50.0001L1.35853 63.5832C-0.454633 65.2374 -0.452552 68.0938 1.36303 69.7453L6.86933 74.7541C8.35363 76.1043 10.589 76.2037 12.1872 74.9905L29.3551 61.9587L68.769 97.9167C69.3925 98.5406 70.1246 99.0104 70.9119 99.3171ZM75.0152 27.2989L45.1091 50.0001L75.0152 72.7012V27.2989Z" fill="white"/>
+</mask>
+<g mask="url(#mask0)">
+<path d="M96.4614 10.7962L75.8569 0.875542C73.4719 -0.272773 70.6217 0.211611 68.75 2.08333L1.29858 63.5832C-0.515693 65.2373 -0.513607 68.0937 1.30308 69.7452L6.81272 74.754C8.29793 76.1042 10.5347 76.2036 12.1338 74.9905L93.3609 13.3699C96.086 11.3026 100 13.2462 100 16.6667V16.4275C100 14.0265 98.6246 11.8378 96.4614 10.7962Z" fill="#0065A9"/>
+<g filter="url(#filter0_d)">
+<path d="M96.4614 89.2038L75.8569 99.1245C73.4719 100.273 70.6217 99.7884 68.75 97.9167L1.29858 36.4169C-0.515693 34.7627 -0.513607 31.9063 1.30308 30.2548L6.81272 25.246C8.29793 23.8958 10.5347 23.7964 12.1338 25.0095L93.3609 86.6301C96.086 88.6974 100 86.7538 100 83.3334V83.5726C100 85.9735 98.6246 88.1622 96.4614 89.2038Z" fill="#007ACC"/>
+</g>
+<g filter="url(#filter1_d)">
+<path d="M75.8578 99.1263C73.4721 100.274 70.6219 99.7885 68.75 97.9166C71.0564 100.223 75 98.5895 75 95.3278V4.67213C75 1.41039 71.0564 -0.223106 68.75 2.08329C70.6219 0.211402 73.4721 -0.273666 75.8578 0.873633L96.4587 10.7807C98.6234 11.8217 100 14.0112 100 16.4132V83.5871C100 85.9891 98.6234 88.1786 96.4586 89.2196L75.8578 99.1263Z" fill="#1F9CF0"/>
+</g>
+<g style="mix-blend-mode:overlay" opacity="0.25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M70.8511 99.3171C72.4261 99.9306 74.2221 99.8913 75.8117 99.1264L96.4 89.2197C98.5634 88.1787 99.9392 85.9892 99.9392 83.5871V16.4133C99.9392 14.0112 98.5635 11.8217 96.4001 10.7807L75.8117 0.873695C73.7255 -0.13019 71.2838 0.115699 69.4527 1.44688C69.1912 1.63705 68.942 1.84937 68.7082 2.08335L29.2943 38.0414L12.1264 25.0096C10.5283 23.7964 8.29285 23.8959 6.80855 25.246L1.30225 30.2548C-0.513334 31.9064 -0.515415 34.7627 1.29775 36.4169L16.1863 50L1.29775 63.5832C-0.515415 65.2374 -0.513334 68.0937 1.30225 69.7452L6.80855 74.754C8.29285 76.1042 10.5283 76.2036 12.1264 74.9905L29.2943 61.9586L68.7082 97.9167C69.3317 98.5405 70.0638 99.0104 70.8511 99.3171ZM74.9544 27.2989L45.0483 50L74.9544 72.7012V27.2989Z" fill="url(#paint0_linear)"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d" x="-8.39411" y="15.8291" width="116.727" height="92.2456" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="4.16667"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="overlay" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter1_d" x="60.4167" y="-8.07558" width="47.9167" height="116.151" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="4.16667"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="overlay" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear" x1="49.9392" y1="0.257812" x2="49.9392" y2="99.7423" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
It was suggested by @leovms that I should add a new Artifact for **VSCode 64 bits.**   See https://github.com/Azure/azure-devtestlab/pull/503#issuecomment-963473670

I started from the existing VsCode script, and I modified it to use VSCode 64-bits.  I decided to add an argument for the desktop icon.  (The default VS Code setup does not pollute the desktop with any icon, but the existing VSCode DTL Artifact forces an icon on the global desktop. I added the parameter to the script to make it easier to customize. )

 