### PR TITLE
Terminology change: `account` to `organization`

### DIFF
--- a/Artifacts/linux-vsts-build-agent/Artifactfile.json
+++ b/Artifacts/linux-vsts-build-agent/Artifactfile.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
   "title": "Azure Pipelines Agent for Linux",
   "publisher": "Microsoft",
-  "description": "Downloads and installs the Azure Pipelines agent, registers with the specified Azure DevOps Services account, and adds the VM to the specified agent pool.",
+  "description": "Downloads and installs the Azure Pipelines agent, registers with the specified Azure DevOps Services organization, and adds the VM to the specified agent pool.",
   "tags": [
     "VSTS",
     "Build",

--- a/Artifacts/windows-deploymentgroup/Artifactfile.json
+++ b/Artifacts/windows-deploymentgroup/Artifactfile.json
@@ -8,8 +8,8 @@
     "parameters": {
         "accountUrl": {
             "type": "string",
-            "displayName": "Azure DevOps account URL",
-            "description": "The URL for the Azure DevOps account, e.g. 'myorg' in https://dev.azure.com/myorg."
+            "displayName": "Azure DevOps organization URL",
+            "description": "The URL for the Azure DevOps organization, e.g. 'myorg' in https://dev.azure.com/myorg."
         },
         "projectName": {
             "type": "string",

--- a/Artifacts/windows-vsts-build-agent/Artifactfile.json
+++ b/Artifacts/windows-vsts-build-agent/Artifactfile.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2016-11-28/dtlArtifacts.json",
   "title": "Azure Pipelines Agent",
   "publisher": "Microsoft",
-  "description": "Downloads and installs the Azure Pipelines agent, registers with the specified Azure DevOps Services account, and adds the VM to the specified agent pool.",
+  "description": "Downloads and installs the Azure Pipelines agent, registers with the specified Azure DevOps Services organization, and adds the VM to the specified agent pool.",
   "tags": [
     "VSTS",
     "Build",


### PR DESCRIPTION
**Changes:**
- 3 x `account` --> `organization` (in the context of Azure DevOps)