### PR TITLE
Fix authentication in Az.LabServices module to work in Azure Automation

### DIFF
--- a/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
+++ b/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
@@ -5,9 +5,6 @@
 if ("AzureAutomation/" -ne $env:AZUREPS_HOST_ENVIRONMENT) {
     # We are using strict mode for added safety
     Set-StrictMode -Version Latest
-
-    # We require a relatively new version of Powershell
-    #requires -Version 3.0
 }
 
 # To understand the code below read here: https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-2.1.0
@@ -214,22 +211,11 @@ function ConvertFrom-ISO8601Duration {
 
 function Get-AzureRmCachedAccessToken() {
     $ErrorActionPreference = 'Stop'
-    Set-StrictMode -Off
+    Set-StrictMode -Off 
 
     if ("AzureAutomation/" -eq $env:AZUREPS_HOST_ENVIRONMENT) {
         Write-Verbose "Running in Azure Automation environment..."
-        # We are running in Azure Automation - so need to get the token another way
-        # First, ensure that we're logged in
-        
-        $url = $env:IDENTITY_ENDPOINT
-        $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]" 
-        $headers.Add("X-IDENTITY-HEADER", $env:IDENTITY_HEADER) 
-        $headers.Add("Metadata", "True") 
-        $body = @{resource='https://management.azure.com/' } 
-        $accessToken = Invoke-RestMethod $url -Method 'POST' -Headers $headers -ContentType 'application/x-www-form-urlencoded' -Body $body
-        write-Verbose "Access token object:"
-        $accessToken | ConvertTo-Json -depth 10 | Out-String | Write-Verbose 
-        return $accessToken.access_token
+        return (Get-AzAccessToken).Token
     }
     else {
 

--- a/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
+++ b/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
@@ -22,8 +22,6 @@ $az = Get-Module -Name "Az.Accounts" -ListAvailable
 $justAz = $az -and -not ($azureRm -and $azureRm.Version.Major -ge 6)
 $justAzureRm = $azureRm -and (-not $az)
 
-$VerbosePreference = "continue"
-
 if ($azureRm -and $az) {
     Write-Warning "You have both Az and AzureRm module installed. That is not officially supported. For more read here: https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az"
 }

--- a/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
+++ b/samples/ClassroomLabs/Modules/Library/Az.LabServices.psm1
@@ -1,11 +1,14 @@
 # TODO: consider polling on the operation returned by the API in the header as less expensive for RP
 # TODO: consider creating proper PS1 documentation for each function
 
-# We are using strict mode for added safety
-Set-StrictMode -Version Latest
+# Only set these if not running under Azure Automation
+if ("AzureAutomation/" -ne $env:AZUREPS_HOST_ENVIRONMENT) {
+    # We are using strict mode for added safety
+    Set-StrictMode -Version Latest
 
-# We require a relatively new version of Powershell
-#requires -Version 3.0
+    # We require a relatively new version of Powershell
+    #requires -Version 3.0
+}
 
 # To understand the code below read here: https://docs.microsoft.com/en-us/powershell/azure/migrate-from-azurerm-to-az?view=azps-2.1.0
 # Having both the Az and AzureRm Module installed is not supported, but it is probably common. The library should work in such case, but warn.


### PR DESCRIPTION
Azure Automation now works with Managed Identities (this is the default when creating a new account) instead of the Run As accounts that existed before.  We needed some changes to our module to work in Azure Automation & MSIs correctly!