### PR TITLE
Fix ServiceFabric-LabCluster template

### DIFF
--- a/Environments/ServiceFabric-LabCluster/azuredeploy.json
+++ b/Environments/ServiceFabric-LabCluster/azuredeploy.json
@@ -76,7 +76,7 @@
                 "description": "Client id of cluster application. Required for Windows clusters."
             }
         },
-        "clientapplication": {
+        "clientApplication": {
             "type": "string",
             "defaultValue": "",
             "metadata": {
@@ -187,7 +187,7 @@
                         "value": "[parameters('clusterApplication')]"
                     },
                     "clientapplication": {
-                        "value": "[parameters('clientapplication')]"
+                        "value": "[parameters('clientApplication')]"
                     }
                 }
             }

--- a/Environments/ServiceFabric-LabCluster/azuredeploy.json
+++ b/Environments/ServiceFabric-LabCluster/azuredeploy.json
@@ -61,6 +61,27 @@
             "metadata": {
                 "description": "Public accessible application port #2."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Tenant the cluster- and clientapplication belongs to. Required for Windows clusters."
+            }
+        },
+        "clusterApplication": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Client id of cluster application. Required for Windows clusters."
+            }
+        },
+        "clientapplication": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Client id of client application. Required for Windows clusters."
+            }
         }
     },
     "variables": {
@@ -158,6 +179,15 @@
                     },
                     "nodeDataDrive": {
                         "value": "OS"
+                    },
+                    "tenantId": {
+                        "value": "[parameters('tenantId')]"
+                    },
+                    "clusterApplication": {
+                        "value": "[parameters('clusterApplication')]"
+                    },
+                    "clientapplication": {
+                        "value": "[parameters('clientapplication')]"
                     }
                 }
             }
@@ -215,6 +245,9 @@
                     },
                     "nt0InstanceCount": {
                         "value": "[variables('nt0InstanceCount')]"
+                    },
+                    "storageAccountEndPoint": {
+                        "value": "[resourceGroup().location]"
                     }
                 }
             }


### PR DESCRIPTION
The template for creating a service fabric cluster using DTL, is referencing two QuickStart arm templates. Since our templates last update, both QuickStart templates have added new required parameters, causing the template to fail.

Add the three new parameters, required when deploying a Windows cluster.
Pass in the resource group location as storage location, when deploying a Linux cluster.