### PR TITLE
Explicitly Setting Chocolatey Version

### DIFF
--- a/Artifacts/windows-7zip/install-choco-package.ps1
+++ b/Artifacts/windows-7zip/install-choco-package.ps1
@@ -71,6 +71,8 @@ function Ensure-Chocolatey
     param(
         [string] $ChocoExePath
     )
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
 
     if (-not (Test-Path "$ChocoExePath"))
     {
@@ -179,7 +181,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-7zip/install-choco-package.ps1
+++ b/Artifacts/windows-7zip/install-choco-package.ps1
@@ -71,6 +71,7 @@ function Ensure-Chocolatey
     param(
         [string] $ChocoExePath
     )
+    
     #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
     $env:chocolateyVersion = '1.4.0'
 

--- a/Artifacts/windows-atom/ChocolateyPackageInstaller.ps1
+++ b/Artifacts/windows-atom/ChocolateyPackageInstaller.ps1
@@ -180,6 +180,9 @@ function InstallChocolatey
         [ValidateNotNullOrEmpty()] $chocolateyInstallLog
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     WriteLog 'Installing Chocolatey ...'
 
     Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')) | Out-Null

--- a/Artifacts/windows-awscli/install-choco-package.ps1
+++ b/Artifacts/windows-awscli/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-awscli/install-choco-package.ps1
+++ b/Artifacts/windows-awscli/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-azurepowershell/install-choco-package.ps1
+++ b/Artifacts/windows-azurepowershell/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-azurepowershell/install-choco-package.ps1
+++ b/Artifacts/windows-azurepowershell/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-beyond-compare/install-choco-package.ps1
+++ b/Artifacts/windows-beyond-compare/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-beyond-compare/install-choco-package.ps1
+++ b/Artifacts/windows-beyond-compare/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-chocolatey/install-choco-package.ps1
+++ b/Artifacts/windows-chocolatey/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-chocolatey/install-choco-package.ps1
+++ b/Artifacts/windows-chocolatey/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-chocolateyfeed/ChocolateyFeedInstaller.ps1
+++ b/Artifacts/windows-chocolateyfeed/ChocolateyFeedInstaller.ps1
@@ -186,6 +186,9 @@ function InstallChocolatey
     Param(
         [ValidateNotNullOrEmpty()] $chocolateyInstallLog
     )
+    
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
 
     WriteLog 'Installing Chocolatey ...'
 

--- a/Artifacts/windows-chrome/install-choco-package.ps1
+++ b/Artifacts/windows-chrome/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-chrome/install-choco-package.ps1
+++ b/Artifacts/windows-chrome/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-docker/ChocolateyPackageInstaller.ps1
+++ b/Artifacts/windows-docker/ChocolateyPackageInstaller.ps1
@@ -180,6 +180,9 @@ function InstallChocolatey
         [ValidateNotNullOrEmpty()] $chocolateyInstallLog
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     WriteLog 'Installing Chocolatey ...'
 
     Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')) | Out-Null

--- a/Artifacts/windows-dotnet45/install-choco-package.ps1
+++ b/Artifacts/windows-dotnet45/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-dotnet45/install-choco-package.ps1
+++ b/Artifacts/windows-dotnet45/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-eclipse/install-choco-package.ps1
+++ b/Artifacts/windows-eclipse/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-eclipse/install-choco-package.ps1
+++ b/Artifacts/windows-eclipse/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-firefox/install-choco-package.ps1
+++ b/Artifacts/windows-firefox/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-firefox/install-choco-package.ps1
+++ b/Artifacts/windows-firefox/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-git/install-choco-package.ps1
+++ b/Artifacts/windows-git/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-git/install-choco-package.ps1
+++ b/Artifacts/windows-git/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-intellij/install-choco-package.ps1
+++ b/Artifacts/windows-intellij/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-intellij/install-choco-package.ps1
+++ b/Artifacts/windows-intellij/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-jhipster/ChocolateyPackageInstaller.ps1
+++ b/Artifacts/windows-jhipster/ChocolateyPackageInstaller.ps1
@@ -180,6 +180,9 @@ function InstallChocolatey
         [ValidateNotNullOrEmpty()] $chocolateyInstallLog
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     WriteLog 'Installing Chocolatey ...'
 
     Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')) | Out-Null

--- a/Artifacts/windows-mongodb/install-choco-package.ps1
+++ b/Artifacts/windows-mongodb/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-mongodb/install-choco-package.ps1
+++ b/Artifacts/windows-mongodb/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-node/install-choco-package.ps1
+++ b/Artifacts/windows-node/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-node/install-choco-package.ps1
+++ b/Artifacts/windows-node/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-notepadplusplus/install-choco-package.ps1
+++ b/Artifacts/windows-notepadplusplus/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-notepadplusplus/install-choco-package.ps1
+++ b/Artifacts/windows-notepadplusplus/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-nvm/install-choco-package.ps1
+++ b/Artifacts/windows-nvm/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-nvm/install-choco-package.ps1
+++ b/Artifacts/windows-nvm/install-choco-package.ps1
@@ -71,6 +71,9 @@ function Ensure-Chocolatey
     param(
         [string] $ChocoExePath
     )
+    
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
 
     if (-not (Test-Path "$ChocoExePath"))
     {

--- a/Artifacts/windows-putty/install-choco-package.ps1
+++ b/Artifacts/windows-putty/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-putty/install-choco-package.ps1
+++ b/Artifacts/windows-putty/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-remote-desktop-connection-manager/install-choco-package.ps1
+++ b/Artifacts/windows-remote-desktop-connection-manager/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-remote-desktop-connection-manager/install-choco-package.ps1
+++ b/Artifacts/windows-remote-desktop-connection-manager/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-selenium/install-choco-package.ps1
+++ b/Artifacts/windows-selenium/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-selenium/install-choco-package.ps1
+++ b/Artifacts/windows-selenium/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-slack/ChocolateyPackageInstaller.ps1
+++ b/Artifacts/windows-slack/ChocolateyPackageInstaller.ps1
@@ -180,6 +180,9 @@ function InstallChocolatey
         [ValidateNotNullOrEmpty()] $chocolateyInstallLog
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     WriteLog 'Installing Chocolatey ...'
 
     Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')) | Out-Null

--- a/Artifacts/windows-ssms/install-choco-package.ps1
+++ b/Artifacts/windows-ssms/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-ssms/install-choco-package.ps1
+++ b/Artifacts/windows-ssms/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-sublime-text/install-choco-package.ps1
+++ b/Artifacts/windows-sublime-text/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-sublime-text/install-choco-package.ps1
+++ b/Artifacts/windows-sublime-text/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-sysinternals/install-choco-package.ps1
+++ b/Artifacts/windows-sysinternals/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-sysinternals/install-choco-package.ps1
+++ b/Artifacts/windows-sysinternals/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/Artifacts/windows-webdeploy/install-choco-package.ps1
+++ b/Artifacts/windows-webdeploy/install-choco-package.ps1
@@ -182,7 +182,7 @@ try
     Ensure-PowerShell -Version $PSVersionRequired
     Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
 
-    Write-Host 'Ensuring latest Chocolatey version is installed.'
+    Write-Host 'Ensuring Chocolatey is installed.'
     Ensure-Chocolatey -ChocoExePath "$choco"
 
     Write-Host "Preparing to install Chocolatey packages: $Packages."

--- a/Artifacts/windows-webdeploy/install-choco-package.ps1
+++ b/Artifacts/windows-webdeploy/install-choco-package.ps1
@@ -72,6 +72,9 @@ function Ensure-Chocolatey
         [string] $ChocoExePath
     )
 
+    #Set static version of Chocolatey to 1.4.0, to not cause reboot w/ choco v2
+    $env:chocolateyVersion = '1.4.0'
+
     if (-not (Test-Path "$ChocoExePath"))
     {
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))


### PR DESCRIPTION
Had issues where newer versions of choco would require .NET Framework 4.6 and therefore cause the VM to restart unexpectedly while installing certain artifacts that utilized the chocolatey package manager.

This is a fix to ensure all choco package managers run on version 1.4.0 while installing artifacts, therefore they will not require the restart.