### PR TITLE
vsts-build-agent - Allow Multiple Executions.  Improve error logging.

### DIFF
--- a/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
+++ b/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
@@ -237,7 +237,7 @@ function Extract-AgentPackage
     )
   
     Add-Type -AssemblyName System.IO.Compression.FileSystem 
-    [System.IO.Compression.ZipFile]::ExtractToDirectory("$PackagePath", "$Destination")
+    [System.IO.Compression.ZipFile]::ExtractToDirectory("$PackagePath", "$Destination", $True)
 }
 
 function Prep-MachineForAutologon
@@ -297,9 +297,16 @@ function Prep-MachineForAutologon
     # Check if the registry key required for enabling autologon is present on the machine, if not wait for 120 seconds in case the user profile is still getting created
     while ($timeout -ge 0 -and $canCheckRegistry)
     {
-        $objUser = New-Object System.Security.Principal.NTAccount($Config.WindowsLogonAccount)
-        $securityId = $objUser.Translate([System.Security.Principal.SecurityIdentifier])
-        $securityId = $securityId.Value
+        try
+        {
+          $objUser = New-Object System.Security.Principal.NTAccount($Config.WindowsLogonAccount)
+          $securityId = $objUser.Translate([System.Security.Principal.SecurityIdentifier])
+          $securityId = $securityId.Value
+        }
+        catch
+        {
+            throw "Login '$($Config.WindowsLogonAccount)' could not be mapped to a SID.  Please verify account."
+        }
 
         if (Test-Path "HKU:\\$securityId")
         {


### PR DESCRIPTION
Resolves two quality of life issues customers are facing:
1) Subsequent runs fail due to extraction returning an error when it attempts to extract a file to a path that already exists.
2) Provides a better error message when NTAccount::Translate fails to look up account passed in.