### PR TITLE
Adding code owners for VSEng artifacts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
+/Artifacts/windows-download-artifacts-drop/* @bradselw @plequere-ms
+/Artifacts/windows-execute-powershell-script/* @bradselw @plequere-ms
 /samples/DevTestLabs/Modules/Library/   @lucabol @petehauge @rogerbestmsft


### PR DESCRIPTION
Adding myself and my manager as code owners for the two artifacts that our team owns.

Ideally, we would add our `@microsoft/visual-studio-engineering` team as an owner, but GitHub does not allow cross-organization ownership. I will look into getting our team replicated in the `Azure` GitHub organization.