### PR TITLE
Removing nuget.config

### DIFF
--- a/samples/DevTestLabs/nuget.config
+++ b/samples/DevTestLabs/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="dtl-github-feed" value="https://pkgs.dev.azure.com/devdiv/OnlineServices/_packaging/dtl-github-feed/nuget/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
It was originally thought that we could add a nuget.config file to use artifacts from a private feed, but seeing this is a public repo that would cause build issues. Instead I am removing this file and then adding the private feed to the pipeline 