### PR TITLE
Update vsts-agent-install.ps1

### DIFF
--- a/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
+++ b/Artifacts/windows-vsts-build-agent/vsts-agent-install.ps1
@@ -281,7 +281,7 @@ function Prep-MachineForAutologon
       $userName = $Config.WindowsLogonAccount
     }
 
-    $credentials = New-Object System.Management.Automation.PSCredential("$domain\\$userName", $password)
+    $credentials = New-Object System.Management.Automation.PSCredential("$domain\$userName", $password)
     Enter-PSSession -ComputerName $computerName -Credential $credentials
     Exit-PSSession
 


### PR DESCRIPTION
Currently Interactive Agent is failed with error like **_`"ERROR: Connecting to remote server localhost failed with the following error message : Access is denied. For more information, see the about_Remote_Troubleshooting Help topic."`_**.

Its caused while establishing the powershell session due to invalid username format.
Removed the character slash(\) to fix the above error and for successful creation of session and interactive agent creation.