### PR TITLE
Migrate Azure DevTest Labs Tasks from Node10 to Node24 LTS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "azure-devtestlab",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "azure-devtestlab",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/tasks/Node/README.md
+++ b/tasks/Node/README.md
@@ -17,7 +17,7 @@ The following are tools used to create these tasks and are recommended.
 
 * The latest version of [Visual Studio Code](https://code.visualstudio.com/).
 * The latest version of [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest).
-* The latest version of [Node.js](https://nodejs.org/en/download/).
+* [Node.js](https://nodejs.org/en/download/) v24 LTS or later.
 * [Typescript Compiler](https://www.npmjs.com/package/typescript) v2.2.0 or later.
   * This should already be part of the dependencies, when configuring the project for the first time.
   * If you have problems running it, simply install it globally: `npm install typescript -g`

--- a/tasks/Node/package.json
+++ b/tasks/Node/package.json
@@ -14,12 +14,12 @@
     "isomorphic-fetch": "^3.0.0",
     "minimist": "^1.2.6",
     "tough-cookie": "^4.0.0",
-    "axios": "^0.21.4"
+    "axios": "^1.7.0"
   },
   "devDependencies": {
     "@types/mocha": "^8.2.2",
     "@types/ncp": "^2.0.4",
-    "@types/node": "^15.0.2",
+    "@types/node": "^24.0.0",
     "@types/q": "^1.5.4",
     "ansi-regex": "^6.0.1",
     "immer": "^9.0.6",

--- a/tasks/Node/src/tasks/AzureDtlCreateCustomImage/task.json
+++ b/tasks/Node/src/tasks/AzureDtlCreateCustomImage/task.json
@@ -152,7 +152,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node24": {
             "target": "task.js"
         }
     }

--- a/tasks/Node/src/tasks/AzureDtlCreateEnvironment/task.json
+++ b/tasks/Node/src/tasks/AzureDtlCreateEnvironment/task.json
@@ -180,7 +180,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node24": {
             "target": "task.js"
         }
     }

--- a/tasks/Node/src/tasks/AzureDtlCreateVM/task.json
+++ b/tasks/Node/src/tasks/AzureDtlCreateVM/task.json
@@ -168,7 +168,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node24": {
             "target": "task.js"
         }
     }

--- a/tasks/Node/src/tasks/AzureDtlDeleteCustomImage/task.json
+++ b/tasks/Node/src/tasks/AzureDtlDeleteCustomImage/task.json
@@ -74,7 +74,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node24": {
             "target": "task.js"
         }
     }

--- a/tasks/Node/src/tasks/AzureDtlDeleteEnvironment/task.json
+++ b/tasks/Node/src/tasks/AzureDtlDeleteEnvironment/task.json
@@ -74,7 +74,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node24": {
             "target": "task.js"
         }
     }

--- a/tasks/Node/src/tasks/AzureDtlDeleteVM/task.json
+++ b/tasks/Node/src/tasks/AzureDtlDeleteVM/task.json
@@ -74,7 +74,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node24": {
             "target": "task.js"
         }
     }

--- a/tasks/Node/src/tasks/AzureDtlUpdateEnvironment/task.json
+++ b/tasks/Node/src/tasks/AzureDtlUpdateEnvironment/task.json
@@ -152,7 +152,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node24": {
             "target": "task.js"
         }
     }


### PR DESCRIPTION
- Updated all task.json execution configurations from Node10 to Node24
- Updated @types/node from ^15.0.2 to ^24.0.0
- Updated axios from ^0.21.4 to latest version for security
- Updated README to specify Node.js v24 LTS requirement